### PR TITLE
Point to the right binary of the portal implementation in the service file

### DIFF
--- a/org.freedesktop.impl.portal.desktop.gtk.service.in
+++ b/org.freedesktop.impl.portal.desktop.gtk.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.desktop.gtk
-Exec=@libexecdir@/flatpak-gtk-portal
+Exec=@libexecdir@/xdg-desktop-portal-gtk


### PR DESCRIPTION
It was still using 'flatpak-gtk', from the old repository