### PR TITLE
Consider the 'use-default' option if present, to avoid using a GtkDialog

### DIFF
--- a/appchooser.c
+++ b/appchooser.c
@@ -130,6 +130,8 @@ handle_choose_application (XdpAppChooser *object,
   const char *accept_label;
   const char *title;
   const char *heading;
+  const char *latest_chosen_id;
+  gint latest_chosen_count;
 
   if (!g_variant_lookup (arg_options, "cancel_label", "&s", &cancel_label))
     cancel_label = "_Cancel";
@@ -139,8 +141,10 @@ handle_choose_application (XdpAppChooser *object,
     title = "Open With";
   if (!g_variant_lookup (arg_options, "heading", "&s", &heading))
     heading = "Select application";
+  if (!g_variant_lookup (arg_options, "latest-choice", "&s", &latest_chosen_id))
+    latest_chosen_id = NULL;
 
-  dialog = GTK_WIDGET (app_chooser_dialog_new (choices, cancel_label, accept_label, title, heading));
+  dialog = GTK_WIDGET (app_chooser_dialog_new (choices, latest_chosen_id, cancel_label, accept_label, title, heading));
 
   handle = app_dialog_handle_new (arg_app_id, arg_sender, dialog, G_DBUS_INTERFACE_SKELETON (object));
 

--- a/appchooserdialog.c
+++ b/appchooserdialog.c
@@ -205,6 +205,7 @@ app_chooser_dialog_class_init (AppChooserDialogClass *class)
 
 AppChooserDialog *
 app_chooser_dialog_new (const char **choices,
+                        const char *default_id,
                         const char *cancel_label,
                         const char *accept_label,
                         const char *title,
@@ -242,6 +243,9 @@ app_chooser_dialog_new (const char **choices,
       gtk_list_box_insert (GTK_LIST_BOX (dialog->list), row, -1);
     }
 
+  if (default_id != NULL)
+    app_chooser_dialog_set_selected (dialog, default_id);
+
   if (n_choices > 4)
     {
       GtkWidget *row;
@@ -261,4 +265,27 @@ app_chooser_dialog_new (const char **choices,
     }
 
   return dialog;
+}
+
+void
+app_chooser_dialog_set_selected (AppChooserDialog *dialog,
+                                 const char *choice_id)
+{
+  AppChooserRow *row = NULL;
+  GAppInfo *info = NULL;
+  g_autoptr(GList) choices = NULL;
+  GList *l = NULL;
+
+  choices = gtk_container_get_children (GTK_CONTAINER (dialog->list));
+  for (l = choices; l != NULL; l = g_list_next (l))
+    {
+      row = APP_CHOOSER_ROW (l->data);
+      info = app_chooser_row_get_info (row);
+
+      if (g_strcmp0 (choice_id, g_app_info_get_id (info)) == 0)
+        {
+          g_signal_emit_by_name (GTK_LIST_BOX (dialog->list), "row-activated", row, dialog);
+          break;
+        }
+    }
 }

--- a/appchooserdialog.h
+++ b/appchooserdialog.h
@@ -3,7 +3,9 @@
 G_DECLARE_FINAL_TYPE (AppChooserDialog, app_chooser_dialog, APP, CHOOSER_DIALOG, GtkWindow)
 
 AppChooserDialog * app_chooser_dialog_new (const char **app_ids,
+                                           const char *default_id,
                                            const char *cancel_label,
                                            const char *accept_label,
                                            const char *title,
                                            const char *heading);
+void app_chooser_dialog_set_selected (AppChooserDialog *dialog, const char *choice_id);

--- a/appchooserdialog.h
+++ b/appchooserdialog.h
@@ -7,4 +7,3 @@ AppChooserDialog * app_chooser_dialog_new (const char **app_ids,
                                            const char *accept_label,
                                            const char *title,
                                            const char *heading);
-const char *app_chooser_dialog_get_selected (AppChooserDialog *dialog);


### PR DESCRIPTION
This addresses issue https://github.com/flatpak/xdg-desktop-portal/issues/10