### PR TITLE
Set gettext domain in ui files

### DIFF
--- a/appchooserdialog.ui
+++ b/appchooserdialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface>
+<interface domain="xdg-desktop-portal-gtk">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="AppChooserDialog" parent="GtkWindow">
     <property name="type-hint">dialog</property>

--- a/appchooserrow.ui
+++ b/appchooserrow.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface>
+<interface domain="xdg-desktop-portal-gtk">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="AppChooserRow" parent="GtkListBoxRow">
     <property name="selectable">0</property>

--- a/screenshotdialog.ui
+++ b/screenshotdialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface>
+<interface  domain="xdg-desktop-portal-gtk">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="ScreenshotDialog" parent="GtkWindow">
     <property name="type-hint">dialog</property>


### PR DESCRIPTION
These contain translatable strings, but they won't be translated
at runtime unless we tell GtkBuilder about the domain.