### PR TITLE
Interface org.gnome.Shell.Screenshot.xml doesn't come from xdg-deskto…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -31,7 +31,7 @@ BUILT_SOURCES += $(shell_built_sources)
 $(shell_built_sources): Makefile.am
 	$(AM_V_GEN) $(GDBUS_CODEGEN)			\
 	--generate-c-code shell-dbus	\
-	$(DESKTOP_PORTAL_INTERFACES_DIR)/org.gnome.Shell.Screenshot.xml	\
+	$(DBUS_INTERFACES_DIR)/org.gnome.Shell.Screenshot.xml	\
 	$(top_srcdir)/org.gtk.Notifications.xml				\
 	$(NULL)
 

--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,7 @@ DBUS_SERVICE_DIR=$with_dbus_service_dir
 AC_SUBST(DBUS_SERVICE_DIR)
 
 AC_SUBST([DESKTOP_PORTAL_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir xdg-desktop-portal`])
+AC_SUBST([DBUS_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir dbus-1`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 


### PR DESCRIPTION
…p-portal

...but from gnome-shell, so shouldn't be accessed via
DESKTOP_PORTAL_INTERFACES_DIR (which doesn't work if xdg-desktop-portal isn't
installed into the system).  (No idea whether there is a more correct way to
query pkg-config for the gnome-shell interface dir, though.)