### PR TITLE
build: Add appropriate inclusion paths

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -104,4 +104,6 @@ xdg_desktop_portal_gtk_CFLAGS = $(BASE_CFLAGS) $(GTK_CFLAGS) $(GTK_X11_CFLAGS)
 xdg_desktop_portal_gtk_CPPFLAGS = \
 	-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\"        \
 	-DLOCALEDIR=\"$(localedir)\"                    \
+	-I$(top_srcdir)/src				\
+	-I$(top_builddir)/src				\
 	$(NULL)


### PR DESCRIPTION
When building outside of the srcdir, we need to tweak the inclusion paths.

This fixes the build for `builddir != srcdir` environments, like GNOME Continuous.