### PR TITLE
configure: Update GTK+ dependency

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_SUBST([DBUS_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir dbus-1`]
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 
-PKG_CHECK_MODULES(GTK, [xdg-desktop-portal gtk+-3.0 gtk+-unix-print-3.0])
+PKG_CHECK_MODULES(GTK, [xdg-desktop-portal glib-2.0 >= 2.44 gtk+-3.0 >= 3.14 gtk+-unix-print-3.0])
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)
 

--- a/src/access.c
+++ b/src/access.c
@@ -329,7 +329,15 @@ handle_access_dialog (XdpImplAccess *object,
       body_label = gtk_label_new (arg_body);
       gtk_widget_set_halign (body_label, GTK_ALIGN_START);
       g_object_set (body_label, "margin-top", 10, NULL);
+#if GTK_CHECK_VERSION (3,16,0)
       gtk_label_set_xalign (GTK_LABEL (body_label), 0);
+#else
+G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+      /* This is deprecated in 3.14, but gtk_label_set_xalign() is not
+       * available until 3.16. */
+      gtk_misc_set_alignment (GTK_MISC (body_label), 0.0, 0.5);
+G_GNUC_END_IGNORE_DEPRECATIONS
+#endif
       gtk_label_set_line_wrap (GTK_LABEL (body_label), TRUE);
       gtk_label_set_max_width_chars (GTK_LABEL (body_label), 50);
       gtk_widget_show (body_label);

--- a/src/accountdialog.h
+++ b/src/accountdialog.h
@@ -1,6 +1,10 @@
 #include <gtk/gtk.h>
 
-G_DECLARE_FINAL_TYPE (AccountDialog, account_dialog, ACCOUNT, DIALOG, GtkWindow)
+#define ACCOUNT_TYPE_DIALOG (account_dialog_get_type ())
+#define ACCOUNT_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST (object, ACCOUNT_TYPE_DIALOG, AccountDialog))
+
+typedef struct _AccountDialog AccountDialog;
+typedef struct _AccountDialogClass AccountDialogClass;
 
 AccountDialog * account_dialog_new (const char *app_id,
                                     const char *user_name,

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -241,7 +241,7 @@ app_chooser_dialog_new (const char **choices,
   if (provider == NULL)
     {
       provider = gtk_css_provider_new ();
-      gtk_css_provider_load_from_resource (provider, "/org/freedesktop/portal/desktop/gtk/appchooserdialog.css");
+      gtk_css_provider_load_from_path (provider, "resource:///org/freedesktop/portal/desktop/gtk/appchooserdialog.css", NULL);
       gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
                                                  GTK_STYLE_PROVIDER (provider),
                                                  GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -181,7 +181,12 @@ search_toggled (GtkToggleButton *button,
       show_all (dialog);
       gtk_list_box_set_filter_func (GTK_LIST_BOX (dialog->list),
                                     filter_func, dialog, NULL);
+#if GTK_CHECK_VERSION (3, 16, 0)
       gtk_entry_grab_focus_without_selecting (GTK_ENTRY (dialog->search_entry));
+#else
+      gtk_widget_grab_focus (dialog->search_entry);
+      gtk_editable_set_position (GTK_EDITABLE (dialog->search_entry), -1);
+#endif
     }
   else
     {

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -144,6 +144,57 @@ search_changed (GtkSearchEntry *entry,
   gtk_list_box_invalidate_filter (GTK_LIST_BOX (dialog->list));
 }
 
+/* gtk_search_entry_handle_event() was not added until GTK+ 3.16. */
+#if !GTK_CHECK_VERSION (3, 16, 0)
+static gboolean
+gtk_search_entry_is_keynav_event (GdkEvent *event)
+{
+  GdkModifierType state = 0;
+  guint keyval;
+
+  if (!gdk_event_get_keyval (event, &keyval))
+    return FALSE;
+
+  gdk_event_get_state (event, &state);
+
+  if (keyval == GDK_KEY_Tab       || keyval == GDK_KEY_KP_Tab ||
+      keyval == GDK_KEY_Up        || keyval == GDK_KEY_KP_Up ||
+      keyval == GDK_KEY_Down      || keyval == GDK_KEY_KP_Down ||
+      keyval == GDK_KEY_Left      || keyval == GDK_KEY_KP_Left ||
+      keyval == GDK_KEY_Right     || keyval == GDK_KEY_KP_Right ||
+      keyval == GDK_KEY_Home      || keyval == GDK_KEY_KP_Home ||
+      keyval == GDK_KEY_End       || keyval == GDK_KEY_KP_End ||
+      keyval == GDK_KEY_Page_Up   || keyval == GDK_KEY_KP_Page_Up ||
+      keyval == GDK_KEY_Page_Down || keyval == GDK_KEY_KP_Page_Down ||
+      ((state & (GDK_CONTROL_MASK | GDK_MOD1_MASK)) != 0))
+        return TRUE;
+
+  /* Other navigation events should get automatically
+   * ignored as they will not change the content of the entry
+   */
+  return FALSE;
+}
+
+static gboolean
+gtk_search_entry_handle_event (GtkSearchEntry *entry,
+                               GdkEvent       *event)
+{
+  gboolean handled;
+
+  if (!gtk_widget_get_realized (GTK_WIDGET (entry)))
+    gtk_widget_realize (GTK_WIDGET (entry));
+
+  if (gtk_search_entry_is_keynav_event (event) ||
+      event->key.keyval == GDK_KEY_space ||
+      event->key.keyval == GDK_KEY_Menu)
+    return GDK_EVENT_PROPAGATE;
+
+  handled = gtk_widget_event (GTK_WIDGET (entry), event);
+
+  return handled ? GDK_EVENT_STOP : GDK_EVENT_PROPAGATE;
+}
+#endif
+
 static gboolean
 app_chooser_dialog_key_press (GtkWidget *widget,
                               GdkEventKey *event)

--- a/src/appchooserdialog.h
+++ b/src/appchooserdialog.h
@@ -22,7 +22,11 @@
 
 #include <gtk/gtk.h>
 
-G_DECLARE_FINAL_TYPE (AppChooserDialog, app_chooser_dialog, APP, CHOOSER_DIALOG, GtkWindow)
+#define APP_TYPE_CHOOSER_DIALOG (app_chooser_dialog_get_type ())
+#define APP_CHOOSER_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST (object, APP_TYPE_CHOOSER_DIALOG, AppChooserDialog))
+
+typedef struct _AppChooserDialog AppChooserDialog;
+typedef struct _AppChooserDialogClass AppChooserDialogClass;
 
 AppChooserDialog * app_chooser_dialog_new (const char **app_ids,
                                            const char *default_id,

--- a/src/appchooserrow.h
+++ b/src/appchooserrow.h
@@ -22,8 +22,13 @@
 
 #include <gtk/gtk.h>
 
-G_DECLARE_FINAL_TYPE (AppChooserRow, app_chooser_row, APP, CHOOSER_ROW, GtkListBox)
+#define APP_TYPE_CHOOSER_ROW (app_chooser_row_get_type ())
+#define APP_CHOOSER_ROW(object) (G_TYPE_CHECK_INSTANCE_CAST (object, APP_TYPE_CHOOSER_ROW, AppChooserRow))
 
+typedef struct _AppChooserRow AppChooserRow;
+typedef struct _AppChooserRowClass AppChooserRowClass;
+
+GType app_chooser_row_get_type (void);
 AppChooserRow *app_chooser_row_new (GAppInfo *info);
 void app_chooser_row_set_selected (AppChooserRow *row,
                                    gboolean selected);

--- a/src/externalwindow-wayland.c
+++ b/src/externalwindow-wayland.c
@@ -34,6 +34,11 @@ struct _ExternalWindowWayland
   char *handle_str;
 };
 
+struct _ExternalWindowWaylandClass
+{
+  ExternalWindowClass parent_class;
+};
+
 G_DEFINE_TYPE (ExternalWindowWayland, external_window_wayland,
                EXTERNAL_TYPE_WINDOW)
 

--- a/src/externalwindow-wayland.h
+++ b/src/externalwindow-wayland.h
@@ -25,7 +25,10 @@
 #include "externalwindow.h"
 
 #define EXTERNAL_TYPE_WINDOW_WAYLAND (external_window_wayland_get_type ())
-G_DECLARE_FINAL_TYPE (ExternalWindowWayland, external_window_wayland,
-		      EXTERNAL, WINDOW_WAYLAND, ExternalWindow)
+#define EXTERNAL_WINDOW_WAYLAND(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW_WAYLAND, ExternalWindowWayland))
 
+typedef struct _ExternalWindowWayland ExternalWindowWayland;
+typedef struct _ExternalWindowWaylandClass ExternalWindowWaylandClass;
+
+GType external_window_wayland_get_type (void);
 ExternalWindowWayland *external_window_wayland_new (const char *handle_str);

--- a/src/externalwindow-x11.c
+++ b/src/externalwindow-x11.c
@@ -37,6 +37,11 @@ struct _ExternalWindowX11
   GdkWindow *foreign_gdk_window;
 };
 
+struct _ExternalWindowX11Class
+{
+  ExternalWindowClass parent_class;
+};
+
 G_DEFINE_TYPE (ExternalWindowX11, external_window_x11,
                EXTERNAL_TYPE_WINDOW)
 

--- a/src/externalwindow-x11.h
+++ b/src/externalwindow-x11.h
@@ -26,7 +26,10 @@
 
 
 #define EXTERNAL_TYPE_WINDOW_X11 (external_window_x11_get_type ())
-G_DECLARE_FINAL_TYPE (ExternalWindowX11, external_window_x11,
-		      EXTERNAL, WINDOW_X11, ExternalWindow)
+#define EXTERNAL_WINDOW_X11(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW_X11, ExternalWindowX11))
 
+typedef struct _ExternalWindowX11 ExternalWindowX11;
+typedef struct _ExternalWindowX11Class ExternalWindowX11Class;
+
+GType external_window_get_type (void);
 ExternalWindowX11 *external_window_x11_new (const char *handle_str);

--- a/src/externalwindow.h
+++ b/src/externalwindow.h
@@ -25,8 +25,17 @@
 
 
 #define EXTERNAL_TYPE_WINDOW (external_window_get_type ())
-G_DECLARE_DERIVABLE_TYPE (ExternalWindow, external_window,
-			  EXTERNAL, WINDOW, GObject)
+#define EXTERNAL_WINDOW(object) (G_TYPE_CHECK_INSTANCE_CAST (object, EXTERNAL_TYPE_WINDOW, ExternalWindow))
+#define EXTERNAL_WINDOW_CLASS(klass) (G_TYPE_CHECK_CLASS_CAST (klass, EXTERNAL_TYPE_WINDOW, ExternalWindowClass))
+#define EXTERNAL_WINDOW_GET_CLASS(klass) (G_TYPE_INSTANCE_GET_CLASS (klass, EXTERNAL_TYPE_WINDOW, ExternalWindowClass))
+
+typedef struct _ExternalWindow ExternalWindow;
+typedef struct _ExternalWindowClass ExternalWindowClass;
+
+struct _ExternalWindow
+{
+  GObject parent_instance;
+};
 
 struct _ExternalWindowClass
 {
@@ -36,6 +45,7 @@ struct _ExternalWindowClass
                          GdkWindow      *child_window);
 };
 
+GType external_window_get_type (void);
 ExternalWindow *create_external_window_from_handle (const char *handle_str);
 
 void external_window_set_parent_of (ExternalWindow *external_window,

--- a/src/print.c
+++ b/src/print.c
@@ -176,7 +176,7 @@ print_file (int fd,
             GtkPageSetup *page_setup,
             GError **error)
 {
-  g_autoptr(GtkPrintJob) job = NULL;
+  GtkPrintJob *job;
   g_autofree char *title = NULL;
 
   title = g_strdup_printf ("Document from %s", app_id);
@@ -184,9 +184,13 @@ print_file (int fd,
   job = gtk_print_job_new (title, printer, settings, page_setup);
 
   if (!gtk_print_job_set_source_fd (job, fd, error))
-    return FALSE;
+    {
+      g_object_unref (job);
+      return FALSE;
+    }
 
   gtk_print_job_send (job, NULL, NULL, NULL);
+  g_object_unref (job);
 
   return TRUE;
 }
@@ -215,7 +219,7 @@ handle_print_response (GtkDialog *dialog,
     case GTK_RESPONSE_OK:
       {
         GtkPrinter *printer;
-        g_autoptr(GtkPrintSettings) settings = NULL;
+        GtkPrintSettings *settings;
         GtkPageSetup *page_setup;
 
         printer = gtk_print_unix_dialog_get_selected_printer (GTK_PRINT_UNIX_DIALOG (handle->dialog));
@@ -231,6 +235,8 @@ handle_print_response (GtkDialog *dialog,
           handle->response = 2;
         else
           handle->response = 0;
+
+        g_object_unref (settings);
       }
       break;
     }

--- a/src/print.c
+++ b/src/print.c
@@ -29,6 +29,8 @@
 
 #include <gio/gio.h>
 #include <gio/gunixfdlist.h>
+#include <gio/gunixinputstream.h>
+#include <gio/gunixoutputstream.h>
 
 #include "xdg-desktop-portal-dbus.h"
 
@@ -178,16 +180,54 @@ print_file (int fd,
 {
   GtkPrintJob *job;
   g_autofree char *title = NULL;
+#if !GTK_CHECK_VERSION (3, 22, 0)
+  g_autofree char *filename = NULL;
+  g_autoptr(GUnixInputStream) istream = NULL;
+  g_autoptr(GUnixOutputStream) ostream = NULL;
+  int fd2;
+#endif
 
   title = g_strdup_printf ("Document from %s", app_id);
 
   job = gtk_print_job_new (title, printer, settings, page_setup);
 
+#if GTK_CHECK_VERSION (3, 22, 0)
   if (!gtk_print_job_set_source_fd (job, fd, error))
     {
       g_object_unref (job);
       return FALSE;
     }
+#else
+  istream = g_unix_input_stream_new (fd, FALSE);
+
+  if ((fd2 = g_file_open_tmp (PACKAGE_NAME "XXXXXX", &filename, error)) == -1)
+    {
+      g_object_unref (job);
+      return FALSE;
+    }
+
+  ostream = g_unix_output_stream_new (fd2, TRUE);
+
+  if (g_output_stream_splice (G_OUTPUT_STREAM (ostream),
+                              G_INPUT_STREAM (istream),
+                              G_OUTPUT_STREAM_SPLICE_NONE,
+                              NULL,
+                              error) == -1)
+    {
+      g_object_unref (job);
+      return FALSE;
+    }
+
+  if (!gtk_print_job_set_source_file (job, filename, error))
+    {
+      g_object_unref (job);
+      return FALSE;
+    }
+
+  /* The file will be removed when the GtkPrintJob closes it (once the job is
+   * complete). */
+  unlink (filename);
+#endif
 
   gtk_print_job_send (job, NULL, NULL, NULL);
   g_object_unref (job);

--- a/src/screenshotdialog.h
+++ b/src/screenshotdialog.h
@@ -1,6 +1,10 @@
 #include <gtk/gtk.h>
 
-G_DECLARE_FINAL_TYPE (ScreenshotDialog, screenshot_dialog, SCREENSHOT, DIALOG, GtkWindow)
+#define SCREENSHOT_TYPE_DIALOG (screenshot_dialog_get_type ())
+#define SCREENSHOT_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST ((object, SCREENSHOT_TYPE_DIALOG, ScreenshotDialog)))
+
+typedef struct _ScreenshotDialog ScreenshotDialog;
+typedef struct _ScreenshotDialogClass ScreenshotDialogClass;
 
 ScreenshotDialog * screenshot_dialog_new (const char *app_id,
                                           const char *filename);


### PR DESCRIPTION
Depend on at least version 3.16 for gtk_label_set_xalign(). This version
of GTK+ also depends on GLib 2.44, which is the minimum needed for
g_autoptr().