### PR TITLE
Add a systemd user unit corresponding to the session service

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,6 +43,15 @@ AC_ARG_WITH(dbus_service_dir,
 DBUS_SERVICE_DIR=$with_dbus_service_dir
 AC_SUBST(DBUS_SERVICE_DIR)
 
+AC_ARG_WITH([systemduserunitdir],
+            [AS_HELP_STRING([--with-systemduserunitdir=DIR],
+                            [Directory for systemd user service files (default=PREFIX/lib/systemd/user)])],
+    [],
+    dnl This is deliberately not ${libdir}: systemd units always go in
+    dnl .../lib, never .../lib64 or .../lib/x86_64-linux-gnu
+    [with_systemduserunitdir='${prefix}/lib/systemd/user'])
+AC_SUBST([systemduserunitdir], [$with_systemduserunitdir])
+
 AC_SUBST([DESKTOP_PORTAL_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir xdg-desktop-portal`])
 AC_SUBST([DBUS_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir dbus-1`])
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -10,8 +10,14 @@ dbus_service_DATA = org.freedesktop.impl.portal.desktop.gtk.service
 
 CLEANFILES += $(dbus_service_DATA)
 
+systemduserunit_in_files = data/xdg-desktop-portal-gtk.service.in
+systemduserunit_DATA = xdg-desktop-portal-gtk.service
+
+CLEANFILES += $(systemduserunit_DATA)
+
 EXTRA_DIST += \
 	$(dbus_service_in_files)                \
+        $(systemduserunit_in_files)             \
         data/org.gtk.Notifications.xml          \
         data/org.gnome.SessionManager.xml       \
         data/org.gnome.Shell.Screenshot.xml     \

--- a/data/org.freedesktop.impl.portal.desktop.gtk.service.in
+++ b/data/org.freedesktop.impl.portal.desktop.gtk.service.in
@@ -1,3 +1,4 @@
 [D-BUS Service]
 Name=org.freedesktop.impl.portal.desktop.gtk
 Exec=@libexecdir@/xdg-desktop-portal-gtk
+SystemdService=xdg-desktop-portal-gtk.service

--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -1,0 +1,7 @@
+[Unit]
+Description=Portal service (GTK+/GNOME implementation)
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.gtk
+ExecStart=@libexecdir@/xdg-desktop-portal-gtk


### PR DESCRIPTION
This puts xdg-desktop-portal-gtk in its own cgroup where systemd can
apply resource limits, etc. if configured to do so, and avoids
inheriting any non-standard execution environment that dbus-daemon
might have.