### PR TITLE
Encode po/Makevars in UTF-8

### DIFF
--- a/po/Makevars
+++ b/po/Makevars
@@ -18,7 +18,7 @@ XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=UTF-8 --keyword=C_:1c,2 
 # or entity, or to disclaim their copyright.  The empty string stands for
 # the public domain; in this case the translators are expected to disclaim
 # their copyright.
-COPYRIGHT_HOLDER = Copyright © 2016 Red Hat
+COPYRIGHT_HOLDER = Copyright Â© 2016 Red Hat
 
 # This tells whether or not to prepend "GNU " prefix to the package
 # name that gets inserted into the header of the $(DOMAIN).pot file.


### PR DESCRIPTION
Current encoding is latin-1. As all po files are UTF-8, I suggest to also use the UTF-8 encoding for Makevars.