### PR TITLE
Install a desktop file

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -15,9 +15,22 @@ systemduserunit_DATA = xdg-desktop-portal-gtk.service
 
 CLEANFILES += $(systemduserunit_DATA)
 
+%.desktop.in: data/%.desktop.in.in
+	$(AM_V_GEN) sed -e "s|@libexecdir[@]|$(libexecdir)|" $< > $@
+
+%.desktop: %.desktop.in
+	$(AM_V_GEN) msgfmt --desktop -d po --template $< -o $@
+
+desktopdir = $(datadir)/applications
+desktop_in_in_files = data/xdg-desktop-portal-gtk.desktop.in.in
+dist_desktop_DATA = xdg-desktop-portal-gtk.desktop
+
+CLEANFILES += $(dist_desktop_DATA)
+
 EXTRA_DIST += \
 	$(dbus_service_in_files)                \
         $(systemduserunit_in_files)             \
+        $(desktop_in_in_files)                  \
         data/org.gtk.Notifications.xml          \
         data/org.gnome.SessionManager.xml       \
         data/org.gnome.Shell.Screenshot.xml     \

--- a/data/xdg-desktop-portal-gtk.desktop.in.in
+++ b/data/xdg-desktop-portal-gtk.desktop.in.in
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Type=Application
+Name=Portal
+Icon=applications-system-symbolic
+Exec=@libexecdir@/xdg-desktop-portal-gtk
+NoDisplay=true

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,3 +7,4 @@ src/appchooserdialog.ui
 src/filechooser.c
 src/screenshotdialog.c
 src/screenshotdialog.ui
+data/xdg-desktop-portal-gtk.desktop.in

--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -184,7 +184,7 @@ main (int argc, char *argv[])
   if (opt_verbose)
     g_log_set_handler (NULL, G_LOG_LEVEL_DEBUG, message_handler, NULL);
 
-  g_set_prgname (argv[0]);
+  g_set_prgname ("xdg-desktop-portal-gtk");
 
   loop = g_main_loop_new (NULL, FALSE);
 


### PR DESCRIPTION
This lets us associate a name and icon with the name
xdg-desktop-portal-gtk, for the cases where we fail to
make the portal dialog transient for an application toplevel
window.