### PR TITLE
.desktop: Tell translators to not translate icon name

### DIFF
--- a/data/xdg-desktop-portal-gtk.desktop.in.in
+++ b/data/xdg-desktop-portal-gtk.desktop.in.in
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Portal
+# TRANSLATORS: Don't translate this text (this is icon name)
 Icon=applications-system-symbolic
 Exec=@libexecdir@/xdg-desktop-portal-gtk
 NoDisplay=true


### PR DESCRIPTION
Add a comment above the msgid, so the translator knows that it is an icon name