### PR TITLE
notification: Fix ::handle-* return values

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -40,7 +40,7 @@ notification_added (GObject      *source,
     g_warning ("Error from gnome-shell: %s", error->message);
 }
 
-static gboolean
+static void
 handle_add_notification_gtk (XdpImplNotification *object,
                              GDBusMethodInvocation *invocation,
                              const char *arg_app_id,
@@ -59,11 +59,9 @@ handle_add_notification_gtk (XdpImplNotification *object,
                                                  NULL);
 
   xdp_impl_notification_complete_add_notification (object, invocation);
-
-  return TRUE;
 }
 
-static gboolean
+static void
 handle_remove_notification_gtk (XdpImplNotification *object,
                                 GDBusMethodInvocation *invocation,
                                 const char *arg_app_id,
@@ -80,8 +78,6 @@ handle_remove_notification_gtk (XdpImplNotification *object,
                                                     NULL);
 
   xdp_impl_notification_complete_remove_notification (object, invocation);
-
-  return TRUE;
 }
 
 /* org.freedesktop.Notifications support.
@@ -550,7 +546,7 @@ has_unprefixed_action (GVariant *notification)
   return FALSE;
 }
 
-static void
+static gboolean
 handle_add_notification (XdpImplNotification *object,
                          GDBusMethodInvocation *invocation,
                          const gchar *arg_app_id,
@@ -563,9 +559,10 @@ handle_add_notification (XdpImplNotification *object,
     handle_add_notification_fdo (object, invocation, arg_app_id, arg_id, arg_notification);
   else
     handle_add_notification_gtk (object, invocation, arg_app_id, arg_id, arg_notification);
+  return TRUE;
 }
 
-static void
+static gboolean
 handle_remove_notification (XdpImplNotification *object,
                             GDBusMethodInvocation *invocation,
                             const gchar *arg_app_id,
@@ -578,6 +575,7 @@ handle_remove_notification (XdpImplNotification *object,
     handle_remove_notification_fdo (object, invocation, arg_app_id, arg_id);
   else
     handle_remove_notification_gtk (object, invocation, arg_app_id, arg_id);
+  return TRUE;
 }
 
 gboolean


### PR DESCRIPTION
When handling incoming method calls via the generated ::handle-*
signals, handlers are expected to return %TRUE to indicate that
the invocation has been handled. In the case that no handler handles
the invocation, the method is considered unknown and a corresponding
D-Bus error is returned.

As we currently connect handlers with no return value at all, we end
up with a Schroedinger method that may or may not exist - as the gtk
code path calls methods that do return %TRUE, there's a good chance
that we are lucky and something true-ish is picked from the stack,
but for the fdo path all bets are off.

Fix this by moving the return values to the actual signal handlers.