### PR TITLE
Fix notification icons in the fdo code path

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -359,7 +359,7 @@ call_notify (GDBusConnection *connection,
     urgency = 1;
   g_variant_builder_add (&hints_builder, "{sv}", "urgency", g_variant_new_byte (urgency));
 
-  icon = g_variant_lookup_value (notification, "icon", G_VARIANT_TYPE_VARIANT);
+  icon = g_variant_lookup_value (notification, "icon", NULL);
   if (icon != NULL)
     {
       g_autoptr(GIcon) gicon = g_icon_deserialize (icon);

--- a/src/notification.c
+++ b/src/notification.c
@@ -308,6 +308,7 @@ call_notify (GDBusConnection *connection,
   GVariant *icon;
   const char *body;
   const char *title;
+  g_autofree char *icon_name = NULL;
   guchar urgency;
   const char *dummy;
   g_autoptr(GVariant) buttons = NULL;
@@ -368,17 +369,17 @@ call_notify (GDBusConnection *connection,
            GFile *file;
 
            file = g_file_icon_get_file (G_FILE_ICON (gicon));
-           g_variant_builder_add (&hints_builder, "{sv}", "image-path",
-                                  g_variant_new_take_string (g_file_get_path (file)));
+           icon_name = g_file_get_path (file);
         }
       else if (G_IS_THEMED_ICON (gicon))
         {
            const gchar* const* icon_names = g_themed_icon_get_names (G_THEMED_ICON (gicon));
-           /* Take first name from GThemedIcon */
-           g_variant_builder_add (&hints_builder, "{sv}", "image-path",
-                                  g_variant_new_string (icon_names[0]));
+           icon_name = g_strdup (icon_names[0]);
         }
     }
+
+  if (icon_name == NULL)
+    icon_name = g_strdup ("");
 
   if (!g_variant_lookup (notification, "body", "&s", &body))
     body = "";
@@ -393,7 +394,7 @@ call_notify (GDBusConnection *connection,
                           g_variant_new ("(susssasa{sv}i)",
                                          "", /* app name */
                                          replace_id,
-                                         "", /* app icon */
+                                         icon_name,
                                          title,
                                          body,
                                          &action_builder,


### PR DESCRIPTION
See patches.

I'm including the last one for completeness, but maybe we should leave it out so the unloved option can die a slow death ...