### PR TITLE
externalwindow: Add a missing break in a switch statement

### DIFF
--- a/src/externalwindow.c
+++ b/src/externalwindow.c
@@ -131,6 +131,7 @@ external_window_get_property (GObject    *object,
     {
     case PROP_DISPLAY:
       g_value_set_object (value, priv->display);
+      break;
 
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);


### PR DESCRIPTION
Spotted by Coverity, CID 207681.

Signed-off-by: Philip Withnall <withnall@endlessm.com>