### PR TITLE
Add options to the screenshot portal

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -48,6 +48,7 @@ EXTRA_DIST += \
         src/appchooserdialog.css                        \
         src/appchooserrow.ui                            \
         src/screenshotdialog.ui                         \
+        src/screenshotdialog.css                        \
         src/accountdialog.ui                            \
 	$(NULL)
 

--- a/src/screenshotdialog.c
+++ b/src/screenshotdialog.c
@@ -8,6 +8,7 @@
 #include <glib/gi18n.h>
 
 #include "screenshotdialog.h"
+#include "xdg-desktop-portal-dbus.h"
 
 struct _ScreenshotDialog {
   GtkWindow parent;
@@ -15,6 +16,22 @@ struct _ScreenshotDialog {
   GtkWidget *image;
   GtkWidget *heading;
   GtkWidget *accept_button;
+  GtkWidget *options_button;
+  GtkWidget *cancel_button;
+  GtkWidget *screenshot_button;
+  GtkWidget *stack;
+  GtkWidget *header_stack;
+  GtkWidget *delay_box;
+
+  char *filename;
+
+  GActionGroup *actions;
+  GtkAdjustment *delay_adjustment;
+
+  guint timeout;
+
+  OrgGnomeShellScreenshot *shell;
+  GCancellable *cancellable;
 };
 
 struct _ScreenshotDialogClass {
@@ -31,9 +48,280 @@ static guint signals[LAST_SIGNAL];
 G_DEFINE_TYPE (ScreenshotDialog, screenshot_dialog, GTK_TYPE_WINDOW)
 
 static void
+update_border (ScreenshotDialog *dialog,
+               const char *kind)
+{
+  GAction *border;
+  GAction *pointer;
+
+  border = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "border");
+  pointer = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "pointer");
+
+  if (strcmp (kind, "screen") == 0)
+    {
+      g_simple_action_set_state (G_SIMPLE_ACTION (border), g_variant_new_boolean (FALSE));
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (border), FALSE);
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (pointer), TRUE);
+      gtk_widget_set_sensitive (dialog->delay_box, TRUE);
+    }
+  else if (strcmp (kind, "window") == 0)
+    {
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (border), TRUE);
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (pointer), TRUE);
+      gtk_widget_set_sensitive (dialog->delay_box, TRUE);
+    }
+  else
+    {
+      g_simple_action_set_state (G_SIMPLE_ACTION (border), g_variant_new_boolean (FALSE));
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (border), FALSE);
+      g_simple_action_set_state (G_SIMPLE_ACTION (pointer), g_variant_new_boolean (FALSE));
+      g_simple_action_set_enabled (G_SIMPLE_ACTION (pointer), FALSE);
+      gtk_widget_set_sensitive (dialog->delay_box, FALSE);
+    }
+}
+
+static void
+change_grab (GSimpleAction *action,
+             GVariant *value,
+             gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  g_autoptr (GVariant) window = NULL;
+  const char *kind;
+
+  g_simple_action_set_state (action, value);
+
+  kind = g_variant_get_string (value, NULL);
+  update_border (dialog, kind);
+}
+
+static GActionEntry entries[] = {
+  { "grab", NULL, "s", "'screen'", change_grab },
+  { "pointer", NULL, NULL, "false", NULL },
+  { "border", NULL, NULL, "false", NULL }
+};
+
+static void
 screenshot_dialog_init (ScreenshotDialog *dialog)
 {
   gtk_widget_init_template (GTK_WIDGET (dialog));
+
+  dialog->cancellable = g_cancellable_new ();
+
+  dialog->actions = G_ACTION_GROUP (g_simple_action_group_new ());
+  g_action_map_add_action_entries (G_ACTION_MAP (dialog->actions),
+                                   entries,
+                                   G_N_ELEMENTS (entries),
+                                   dialog);
+  update_border (dialog, "window");
+  gtk_widget_insert_action_group (GTK_WIDGET (dialog), "dialog", dialog->actions);
+}
+
+static void
+show_options (ScreenshotDialog *dialog)
+{
+  gtk_stack_set_visible_child_name (GTK_STACK (dialog->stack), "options");
+  gtk_stack_set_visible_child_name (GTK_STACK (dialog->header_stack), "options");
+}
+
+static void
+show_screenshot (ScreenshotDialog *dialog,
+                 const char *filename)
+{
+  g_autoptr(GdkPixbuf) pixbuf = NULL;
+
+  g_free (dialog->filename);
+  dialog->filename = g_strdup (filename);
+
+  pixbuf = gdk_pixbuf_new_from_file_at_scale (filename, 500, 400, TRUE, NULL);
+  gtk_image_set_from_pixbuf (GTK_IMAGE (dialog->image), pixbuf);
+
+  gtk_stack_set_visible_child_name (GTK_STACK (dialog->stack), "screenshot");
+  gtk_stack_set_visible_child_name (GTK_STACK (dialog->header_stack), "screenshot");
+}
+
+static void
+screenshot_done (GObject *source,
+                 GAsyncResult *result,
+                 gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  gboolean success;
+  g_autofree char *filename = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!org_gnome_shell_screenshot_call_screenshot_finish (dialog->shell,
+                                                          &success,
+                                                          &filename,
+                                                          result,
+                                                          &error))
+    {
+      g_print ("Failed to get screenshot: %s\n", error->message);
+      return;
+    }
+
+  show_screenshot (dialog, filename);
+  gtk_widget_show (GTK_WIDGET (dialog));
+}
+
+static void
+screenshot_window_done (GObject *source,
+                        GAsyncResult *result,
+                        gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  gboolean success;
+  g_autofree char *filename = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!org_gnome_shell_screenshot_call_screenshot_window_finish (dialog->shell,
+                                                                 &success,
+                                                                 &filename,
+                                                                 result,
+                                                                 &error))
+    {
+      g_print ("Failed to get window screenshot: %s\n", error->message);
+      return;
+    }
+
+  show_screenshot (dialog, filename);
+  gtk_widget_show (GTK_WIDGET (dialog));
+}
+
+static void
+screenshot_area_done (GObject *source,
+                      GAsyncResult *result,
+                      gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  gboolean success;
+  g_autofree char *filename = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!org_gnome_shell_screenshot_call_screenshot_area_finish (dialog->shell,
+                                                               &success,
+                                                               &filename,
+                                                               result,
+                                                               &error))
+    {
+      g_print ("Failed to get area screenshot: %s\n", error->message);
+      return;
+    }
+
+  show_screenshot (dialog, filename);
+  gtk_widget_show (GTK_WIDGET (dialog));
+}
+
+
+static gboolean
+do_take_screenshot (gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  GAction *action;
+  g_autoptr(GVariant) grab = NULL;
+  g_autoptr(GVariant) pointer = NULL;
+  g_autoptr(GVariant) border = NULL;
+  const char *kind;
+  gboolean include_pointer;
+  gboolean include_border;
+
+  action = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "grab");
+  grab = g_action_get_state (action);
+  kind = g_variant_get_string (grab, NULL);
+
+  action = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "pointer");
+  pointer = g_action_get_state (action);
+  include_pointer = g_variant_get_boolean (pointer);
+
+  action = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "border");
+  border = g_action_get_state (action);
+  include_border = g_variant_get_boolean (border);
+
+  if (strcmp (kind, "screen") == 0)
+    {
+      org_gnome_shell_screenshot_call_screenshot (dialog->shell,
+                                                  include_pointer,
+                                                  TRUE,
+                                                  "Screenshot",
+                                                  dialog->cancellable,
+                                                  screenshot_done,
+                                                  dialog);
+    }
+  else if (strcmp (kind, "window") == 0)
+    {
+      org_gnome_shell_screenshot_call_screenshot_window (dialog->shell,
+                                                         include_border,
+                                                         include_pointer,
+                                                         TRUE,
+                                                         "Screenshot",
+                                                         dialog->cancellable,
+                                                         screenshot_window_done,
+                                                         dialog);
+    }
+  else
+    {
+      g_print ("Should not get here, screenshot kind: %s\n", kind);
+    }
+
+  dialog->timeout = 0;
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+select_area_done (GObject *source,
+                  GAsyncResult *result,
+                  gpointer data)
+{
+  ScreenshotDialog *dialog = data;
+  g_autoptr(GError) error = NULL;
+  gint x, y, w, h;
+
+  if (!org_gnome_shell_screenshot_call_select_area_finish (dialog->shell,
+                                                           &x, &y, &w, &h,
+                                                           result,
+                                                           &error))
+    {
+      g_print ("Failed to select area: %s\n", error->message);
+      return;
+    }
+
+  org_gnome_shell_screenshot_call_screenshot_area (dialog->shell,
+                                                   x, y, w, h,
+                                                   TRUE,
+                                                   "Screenshot",
+                                                   dialog->cancellable,
+                                                   screenshot_area_done,
+                                                   dialog);
+}
+
+static void
+take_screenshot (ScreenshotDialog *dialog)
+{
+  GAction *action;
+  g_autoptr(GVariant) grab = NULL;
+  const char *kind;
+
+  action = g_action_map_lookup_action (G_ACTION_MAP (dialog->actions), "grab");
+  grab = g_action_get_state (action);
+  kind = g_variant_get_string (grab, NULL);
+
+  gtk_widget_hide (GTK_WIDGET (dialog));
+
+  if (strcmp (kind, "area") == 0)
+    {
+      org_gnome_shell_screenshot_call_select_area (dialog->shell,
+                                                   dialog->cancellable,
+                                                   select_area_done,
+                                                   dialog);
+    }
+  else
+    {
+      guint interval;
+
+      interval = (guint)gtk_adjustment_get_value (dialog->delay_adjustment);
+      dialog->timeout = g_timeout_add_seconds (interval, do_take_screenshot, dialog);
+    }
 }
 
 static void
@@ -42,20 +330,41 @@ button_clicked (GtkWidget *button,
 {
   int response;
 
-  gtk_widget_hide (GTK_WIDGET (dialog));
-
   if (button == dialog->accept_button)
     response = GTK_RESPONSE_OK;
   else
     response = GTK_RESPONSE_CANCEL;
 
-  g_signal_emit (dialog, signals[DONE], 0, response);
+  gtk_widget_hide (GTK_WIDGET (dialog));
+  g_signal_emit (dialog, signals[DONE], 0, response, dialog->filename);
+}
+
+static void
+screenshot_dialog_finalize (GObject *object)
+{
+  ScreenshotDialog *dialog = SCREENSHOT_DIALOG (object);
+
+  if (dialog->timeout)
+    g_source_remove (dialog->timeout);
+
+  g_cancellable_cancel (dialog->cancellable);
+  g_object_unref (dialog->cancellable);
+
+  g_object_unref (dialog->actions);
+  g_free (dialog->filename);
+
+  g_object_unref (dialog->shell);
+
+  G_OBJECT_CLASS (screenshot_dialog_parent_class)->finalize (object);
 }
 
 static void
 screenshot_dialog_class_init (ScreenshotDialogClass *class)
 {
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (class);
+  GObjectClass *object_class = G_OBJECT_CLASS (class);
+
+  object_class->finalize = screenshot_dialog_finalize;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (class),
@@ -63,24 +372,42 @@ screenshot_dialog_class_init (ScreenshotDialogClass *class)
                                 0,
                                 NULL, NULL,
                                 NULL,
-                                G_TYPE_NONE, 1,
-                                G_TYPE_INT);
+                                G_TYPE_NONE, 2,
+                                G_TYPE_INT, G_TYPE_STRING);
 
   gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/screenshotdialog.ui");
   gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, accept_button);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, cancel_button);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, options_button);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, screenshot_button);
   gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, heading);
   gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, image);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, stack);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, header_stack);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, delay_adjustment);
+  gtk_widget_class_bind_template_child (widget_class, ScreenshotDialog, delay_box);
   gtk_widget_class_bind_template_callback (widget_class, button_clicked);
+  gtk_widget_class_bind_template_callback (widget_class, show_options);
+  gtk_widget_class_bind_template_callback (widget_class, take_screenshot);
 }
 
 ScreenshotDialog *
 screenshot_dialog_new (const char *app_id,
-                       const char *filename)
+                       gboolean interactive,
+                       OrgGnomeShellScreenshot *shell)
 {
   ScreenshotDialog *dialog;
   g_autofree char *heading = NULL;
-  g_autoptr(GdkPixbuf) pixbuf = NULL;
-  g_autoptr(GError) error = NULL;
+  static GtkCssProvider *provider;
+
+  if (provider == NULL)
+    {
+      provider = gtk_css_provider_new ();
+      gtk_css_provider_load_from_resource (provider, "/org/freedesktop/portal/desktop/gtk/screenshotdialog.css");
+      gtk_style_context_add_provider_for_screen (gdk_screen_get_default (),
+                                                 GTK_STYLE_PROVIDER (provider),
+                                                 GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+    }
 
   dialog = g_object_new (screenshot_dialog_get_type (), NULL);
 
@@ -97,11 +424,12 @@ screenshot_dialog_new (const char *app_id,
 
   gtk_label_set_label (GTK_LABEL (dialog->heading), heading);
 
-  pixbuf = gdk_pixbuf_new_from_file_at_scale (filename, 500, 400, TRUE, &error);
-  if (error)
-    g_warning ("Failed to load screenshot %s: %s", filename, error->message);
+  dialog->shell = g_object_ref (shell);
 
-  gtk_image_set_from_pixbuf (GTK_IMAGE (dialog->image), pixbuf);
+  if (interactive)
+    show_options (dialog);
+  else
+    do_take_screenshot (dialog);
 
   return dialog;
 }

--- a/src/screenshotdialog.css
+++ b/src/screenshotdialog.css
@@ -1,0 +1,7 @@
+label.bold-heading {
+  font-weight: bold;
+}
+
+image.screenshot {
+  border: 10px solid white;
+}

--- a/src/screenshotdialog.h
+++ b/src/screenshotdialog.h
@@ -1,10 +1,12 @@
 #include <gtk/gtk.h>
+#include "shell-dbus.h"
 
 #define SCREENSHOT_TYPE_DIALOG (screenshot_dialog_get_type ())
-#define SCREENSHOT_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST ((object, SCREENSHOT_TYPE_DIALOG, ScreenshotDialog)))
+#define SCREENSHOT_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST (object, SCREENSHOT_TYPE_DIALOG, ScreenshotDialog))
 
 typedef struct _ScreenshotDialog ScreenshotDialog;
 typedef struct _ScreenshotDialogClass ScreenshotDialogClass;
 
 ScreenshotDialog * screenshot_dialog_new (const char *app_id,
-                                          const char *filename);
+                                          gboolean interactive,
+                                          OrgGnomeShellScreenshot *shell);

--- a/src/screenshotdialog.ui
+++ b/src/screenshotdialog.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<interface  domain="xdg-desktop-portal-gtk">
+<interface domain="xdg-desktop-portal-gtk">
   <!-- interface-requires gtk+ 3.22 -->
   <template class="ScreenshotDialog" parent="GtkWindow">
     <property name="type-hint">dialog</property>
@@ -12,22 +12,57 @@
           <object class="GtkButton" id="cancel_button">
             <property name="visible">1</property>
             <property name="label" translatable="yes">_Cancel</property>
-            <property name="use_underline">1</property>
+            <property name="use-underline">1</property>
             <signal name="clicked" handler="button_clicked"/>
           </object>
-          <packing>
-            <property name="pack-type">start</property>
-          </packing>
         </child>
         <child>
-          <object class="GtkButton" id="accept_button">
+          <object class="GtkStack" id="header_stack">
             <property name="visible">1</property>
-            <property name="label" translatable="yes">_Share</property>
-            <property name="use_underline">1</property>
-            <signal name="clicked" handler="button_clicked"/>
-            <style>
-              <class name="suggested-action"/>
-            </style>
+            <property name="hhomogeneous">0</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">1</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkButton" id="options_button">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">_Options…</property>
+                    <property name="use-underline">1</property>
+                    <signal name="clicked" handler="show_options" swapped="yes"/>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkButton" id="accept_button">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">_Share</property>
+                    <property name="use-underline">1</property>
+                    <signal name="clicked" handler="button_clicked"/>
+                    <style>
+                      <class name="suggested-action"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="name">screenshot</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="screenshot_button">
+                <property name="visible">1</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Take _Screenshot</property>
+                <property name="use-underline">1</property>
+                <signal name="clicked" handler="take_screenshot" swapped="yes"/>
+                <style>
+                  <class name="suggested-action"/>
+                </style>
+              </object>
+              <packing>
+                <property name="name">options</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="pack-type">end</property>
@@ -36,24 +71,150 @@
       </object>
     </child>
     <child>
-      <object class="GtkBox">
+      <object class="GtkStack" id="stack">
         <property name="visible">1</property>
-        <property name="orientation">vertical</property>
-        <property name="margin">20</property>
-        <property name="spacing">20</property>
         <child>
-          <object class="GtkLabel" id="heading">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="label">Select application to open "Foo"</property>
+            <property name="orientation">vertical</property>
+            <property name="margin">20</property>
+            <property name="spacing">20</property>
+            <child>
+              <object class="GtkLabel" id="heading">
+                <property name="visible">1</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkImage" id="image">
+                <property name="visible">1</property>
+                <property name="expand">1</property>
+                <style>
+                  <class name="screenshot"/>
+                </style>
+              </object>
+            </child>
           </object>
+          <packing>
+            <property name="name">screenshot</property>
+          </packing>
         </child>
         <child>
-          <object class="GtkImage" id="image">
+          <object class="GtkBox">
             <property name="visible">1</property>
-            <property name="expand">1</property>
+            <property name="orientation">vertical</property>
+            <property name="margin">20</property>
+            <property name="spacing">10</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="xalign">0</property>
+                <property name="label" translatable="yes">Take Screenshot</property>
+                <style>
+                  <class name="bold-heading"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="grab_screen">
+                <property name="visible">1</property>
+                <property name="use_underline">1</property>
+                <property name="margin-start">20</property>
+                <property name="label" translatable="yes">Grab the whole sc_reen</property>
+                <property name="action-name">dialog.grab</property>
+                <property name="action-target">'screen'</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="grab_window">
+                <property name="visible">1</property>
+                <property name="use_underline">1</property>
+                <property name="margin-start">20</property>
+                <property name="group">grab_screen</property>
+                <property name="label" translatable="yes">Grab the current _window</property>
+                <property name="action-name">dialog.grab</property>
+                <property name="action-target">'window'</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkRadioButton" id="grab_area">
+                <property name="visible">1</property>
+                <property name="use_underline">1</property>
+                <property name="margin-start">20</property>
+                <property name="group">grab_screen</property>
+                <property name="label" translatable="yes">Select _area to grab</property>
+                <property name="action-name">dialog.grab</property>
+                <property name="action-target">'area'</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkBox" id="delay_box">
+                <property name="visible">1</property>
+                <property name="margin-start">20</property>
+                <property name="spacing">6</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="use_underline">1</property>
+                    <property name="label" translatable="yes">Grab after a _delay of</property>
+                    <property name="mnemonic_widget">delay</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="delay">
+                    <property name="visible">1</property>
+                    <property name="adjustment">delay_adjustment</property>
+                  </object>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">1</property>
+                    <property name="label" translatable="yes">seconds</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">1</property>
+                <property name="xalign">0</property>
+                <property name="margin-top">10</property>
+                <property name="label" translatable="yes">Effects</property>
+                <style>
+                  <class name="bold-heading"/>
+                </style>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="include_pointer">
+                <property name="visible">1</property>
+                <property name="use_underline">1</property>
+                <property name="margin-start">20</property>
+                <property name="label">Include _pointer</property>
+                <property name="action-name">dialog.pointer</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="include_border">
+                <property name="visible">1</property>
+                <property name="use_underline">1</property>
+                <property name="margin-start">20</property>
+                <property name="label">Include the window _border</property>
+                <property name="action-name">dialog.border</property>
+              </object>
+            </child>
           </object>
+          <packing>
+            <property name="name">options</property>
+          </packing>
         </child>
       </object>
     </child>
   </template>
+  <object class="GtkAdjustment" id="delay_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">60</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
 </interface>

--- a/src/xdg-desktop-portal-gtk.gresource.xml
+++ b/src/xdg-desktop-portal-gtk.gresource.xml
@@ -5,6 +5,7 @@
     <file>appchooserrow.ui</file>
     <file>appchooserdialog.css</file>
     <file>screenshotdialog.ui</file>
+    <file>screenshotdialog.css</file>
     <file>accountdialog.ui</file>
   </gresource>
 </gresources>


### PR DESCRIPTION
Similar to gnome-screenshot --interactive, expose options
for window and area screenshots.