### PR TITLE
Screen cast and remote desktop portal backends

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -37,6 +37,7 @@ EXTRA_DIST += \
         $(desktop_in_in_files)                  \
         data/org.gtk.Notifications.xml          \
         data/org.gnome.Mutter.DisplayConfig.xml \
+        data/org.gnome.Mutter.ScreenCast.xml    \
         data/org.gnome.SessionManager.xml       \
         data/org.gnome.Shell.Screenshot.xml     \
         data/org.freedesktop.ScreenSaver.xml    \

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -36,6 +36,7 @@ EXTRA_DIST += \
         $(systemduserunit_in_files)             \
         $(desktop_in_in_files)                  \
         data/org.gtk.Notifications.xml          \
+        data/org.gnome.Mutter.DisplayConfig.xml \
         data/org.gnome.SessionManager.xml       \
         data/org.gnome.Shell.Screenshot.xml     \
         data/org.freedesktop.ScreenSaver.xml    \

--- a/data/gtk.portal
+++ b/data/gtk.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.gtk
-Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;
+Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.ScreenCast;
 UseIn=gnome

--- a/data/gtk.portal
+++ b/data/gtk.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.gtk
-Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.ScreenCast;
+Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;
 UseIn=gnome

--- a/data/org.gnome.Mutter.DisplayConfig.xml
+++ b/data/org.gnome.Mutter.DisplayConfig.xml
@@ -1,0 +1,449 @@
+<!DOCTYPE node PUBLIC
+'-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
+'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<node>
+  <!--
+      org.gnome.Mutter.DisplayConfig:
+      @short_description: display configuration interface
+
+      This interface is used by mutter and gnome-settings-daemon
+      to apply multiple monitor configuration.
+  -->
+
+  <interface name="org.gnome.Mutter.DisplayConfig">
+
+    <!--
+        GetResources:
+	@serial: configuration serial
+	@crtcs: available CRTCs
+	@outputs: available outputs
+	@modes: available modes
+	@max_screen_width:
+	@max_screen_height:
+
+        Retrieves the current layout of the hardware.
+
+        @serial is an unique identifier representing the current state
+        of the screen. It must be passed back to ApplyConfiguration()
+	and will be increased for every configuration change (so that
+	mutter can detect that the new configuration is based on old
+	state).
+
+	A CRTC (CRT controller) is a logical monitor, ie a portion
+	of the compositor coordinate space. It might correspond
+	to multiple monitors, when in clone mode, but not that
+	it is possible to implement clone mode also by setting different
+	CRTCs to the same coordinates.
+
+	The number of CRTCs represent the maximum number of monitors
+	that can be set to expand and it is a HW constraint; if more
+	monitors are connected,	then necessarily some will clone. This
+	is complementary to the concept of the encoder (not exposed in
+	the API), which groups outputs that necessarily will show the
+	same image (again a HW constraint).
+
+	A CRTC is represented by a DBus structure with the following
+	layout:
+	* u ID: the ID in the API of this CRTC
+	* x winsys_id: the low-level ID of this CRTC (which might
+	               be a XID, a KMS handle or something entirely
+		       different)
+	* i x, y, width, height: the geometry of this CRTC
+	                         (might be invalid if the CRTC is not in
+				 use)
+	* i current_mode: the current mode of the CRTC, or -1 if this
+	                  CRTC is not used
+			  Note: the size of the mode will always correspond
+			  to the width and height of the CRTC
+	* u current_transform: the current transform (espressed according
+	                       to the wayland protocol)
+	* au transforms: all possible transforms
+	* a{sv} properties: other high-level properties that affect this
+	                    CRTC; they are not necessarily reflected in
+			    the hardware.
+			    No property is specified in this version of the API.
+
+        Note: all geometry information refers to the untransformed
+	display.
+
+	An output represents a physical screen, connected somewhere to
+	the computer. Floating connectors are not exposed in the API.
+	An output is a DBus struct with the following fields:
+	* u ID: the ID in the API
+	* x winsys_id: the low-level ID of this output (XID or KMS handle)
+	* i current_crtc: the CRTC that is currently driving this output,
+	                  or -1 if the output is disabled
+	* au possible_crtcs: all CRTCs that can control this output
+	* s name: the name of the connector to which the output is attached
+	          (like VGA1 or HDMI)
+	* au modes: valid modes for this output
+	* au clones: valid clones for this output, ie other outputs that
+	             can be assigned the same CRTC as this one; if you
+	             want to mirror two outputs that don't have each other
+	             in the clone list, you must configure two different
+	             CRTCs for the same geometry
+	* a{sv} properties: other high-level properties that affect this
+	                    output; they are not necessarily reflected in
+			    the hardware.
+			    Known properties:
+                            - "vendor" (s): (readonly) the human readable name
+                                            of the manufacturer
+                            - "product" (s): (readonly) the human readable name
+                                             of the display model
+                            - "serial" (s): (readonly) the serial number of this
+                                            particular hardware part
+			    - "display-name" (s): (readonly) a human readable name
+			                          of this output, to be shown in the UI
+	                    - "backlight" (i): (readonly, use the specific interface)
+                                               the backlight value as a percentage
+                                               (-1 if not supported)
+			    - "primary" (b): whether this output is primary
+			                     or not
+			    - "presentation" (b): whether this output is
+			                          for presentation only
+			    Note: properties might be ignored if not consistenly
+			    applied to all outputs in the same clone group. In
+			    general, it's expected that presentation or primary
+			    outputs will not be cloned.
+
+        A mode represents a set of parameters that are applied to
+	each output, such as resolution and refresh rate. It is a separate
+	object so that it can be referenced by CRTCs and outputs.
+	Multiple outputs in the same CRTCs must all have the same mode.
+	A mode is exposed as:
+	* u ID: the ID in the API
+	* x winsys_id: the low-level ID of this mode
+	* u width, height: the resolution
+	* d frequency: refresh rate
+        * u flags: mode flags as defined in xf86drmMode.h and randr.h
+
+        Output and modes are read-only objects (except for output properties),
+	they can change only in accordance to HW changes (such as hotplugging
+	a monitor), while CRTCs can be changed with ApplyConfiguration().
+
+        XXX: actually, if you insist enough, you can add new modes
+	through xrandr command line or the KMS API, overriding what the
+	kernel driver and the EDID say.
+	Usually, it only matters with old cards with broken drivers, or
+	old monitors with broken EDIDs, but it happens more often with
+	projectors (if for example the kernel driver doesn't add the
+	640x480 - 800x600 - 1024x768 default modes). Probably something
+	that we need to handle in mutter anyway.
+    -->
+    <method name="GetResources">
+      <arg name="serial" direction="out" type="u" />
+      <arg name="crtcs" direction="out" type="a(uxiiiiiuaua{sv})" />
+      <arg name="outputs" direction="out" type="a(uxiausauaua{sv})" />
+      <arg name="modes" direction="out" type="a(uxuudu)" />
+      <arg name="max_screen_width" direction="out" type="i" />
+      <arg name="max_screen_height" direction="out" type="i" />
+    </method>
+
+    <!--
+        ApplyConfiguration:
+	@serial: configuration serial
+	@persistent: whether this configuration should be saved on disk
+	@crtcs: new data for CRTCs
+	@outputs: new data for outputs
+
+	Applies the requested configuration changes.
+
+	@serial must match the serial from the last GetResources() call,
+	or org.freedesktop.DBus.AccessDenied will be generated.
+
+	If @persistent is true, mutter will attempt to replicate this
+	configuration the next time this HW layout appears.
+
+	@crtcs represents the new logical configuration, as a list
+	of structures containing:
+	- u ID: the API ID from the corresponding GetResources() call
+	- i new_mode: the API ID of the new mode to configure the CRTC
+	              with, or -1 if the CRTC should be disabled
+        - i x, y: the new coordinates of the top left corner
+	          the geometry will be completed with the size information
+		  from @new_mode
+        - u transform: the desired transform
+	- au outputs: the API ID of outputs that should be assigned to
+	              this CRTC
+        - a{sv} properties: properties whose value should be changed
+
+	Note: CRTCs not referenced in the array will be	disabled.
+
+	@outputs represent the output property changes as:
+	- u ID: the API ID of the output to change
+	- a{sv} properties: properties whose value should be changed
+
+	Note: both for CRTCs and outputs, properties not included in
+	the dictionary will not be changed.
+
+	Note: unrecognized properties will have no effect, but if the
+	configuration change succeeds the property will be reported
+	by the next GetResources() call, and if @persistent is true,
+	it will also be saved to disk.
+
+	If the configuration is invalid according to the previous
+	GetResources() call, for example because a CRTC references
+	an output it cannot drive, or not all outputs support the
+	chosen mode, the error org.freedesktop.DBus.InvalidArgs will
+	be generated.
+
+	If the configuration cannot be applied for any other reason
+	(eg. the screen size would exceed texture limits), the error
+	org.freedesktop.DBus.Error.LimitsExceeded will be generated.
+    -->
+    <method name="ApplyConfiguration">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="persistent" direction="in" type="b" />
+      <arg name="crtcs" direction="in" type="a(uiiiuaua{sv})" />
+      <arg name="outputs" direction="in" type="a(ua{sv})" />
+    </method>
+
+    <!--
+        ChangeBacklight:
+	@serial: configuration serial
+	@output: the API id of the output
+	@value: the new backlight value
+
+	Changes the backlight of @output to @value, which is
+	expressed as a percentage and rounded to the HW limits.
+
+        Returns the new value after rounding.
+    -->
+    <method name="ChangeBacklight">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="output" direction="in" type="u" />
+      <arg name="value" direction="in" type="i" />
+      <arg name="new_value" direction="out" type="i" />
+    </method>
+
+    <!--
+        GetCrtcGamma:
+	@serial: configuration serial
+	@crtc: API id of the crtc
+	@red: red gamma ramp
+	@green: green gamma ramp
+	@blue: blue gamma ramp
+
+	Requests the current gamma ramps of @crtc.
+    -->
+    <method name="GetCrtcGamma">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="crtc" direction="in" type="u" />
+      <arg name="red" direction="out" type="aq" />
+      <arg name="green" direction="out" type="aq" />
+      <arg name="blue" direction="out" type="aq" />
+    </method>
+
+    <!--
+        SetCrtcGamma:
+	@serial: configuration serial
+	@crtc: API id of the crtc
+	@red: red gamma ramp
+	@green: green gamma ramp
+	@blue: blue gamma ramp
+
+	Changes the gamma ramps of @crtc.
+    -->
+    <method name="SetCrtcGamma">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="crtc" direction="in" type="u" />
+      <arg name="red" direction="in" type="aq" />
+      <arg name="green" direction="in" type="aq" />
+      <arg name="blue" direction="in" type="aq" />
+    </method>
+
+    <!--
+        PowerSaveMode:
+
+	Contains the current power saving mode for the screen, and
+	allows changing it.
+
+        Possible values:
+	- 0: on
+	- 1: standby
+	- 2: suspend
+	- 3: off
+	- -1: unknown (unsupported)
+
+        A client should not attempt to change the powersave mode
+	from -1 (unknown) to any other value, and viceversa.
+	Note that the actual effects of the different values
+	depend on the hardware and the kernel driver in use, and
+	it's perfectly possible that all values different than on
+	have the same effect.
+	Also, setting the PowerSaveMode to 3 (off) may or may
+	not have the same effect as disabling all outputs by
+	setting no CRTC on them with ApplyConfiguration(), and
+	may or may not cause a configuration change.
+
+        Also note that this property might become out of date
+	if changed through different means (for example using the
+	XRandR interface directly).
+    -->
+    <property name="PowerSaveMode" type="i" access="readwrite" />
+
+    <!--
+        MonitorsChanged:
+
+	The signal is emitted every time the screen configuration
+	changes.
+	The client should then call GetResources() to read the new layout.
+    -->
+    <signal name="MonitorsChanged" />
+
+    <!--
+	GetCurrentState:
+	@serial: configuration serial
+	@monitors: available monitors
+	@logical_monitors: current logical monitor configuration
+	@properties: display configuration properties
+
+	@monitors represent connected physical monitors
+
+	* s connector: connector name (e.g. HDMI-1, DP-1, etc)
+	* s vendor: vendor name
+	* s product: product name
+	* s serial: product serial
+	* a(siiddada{sv}) modes: available modes
+	    * s id: mode ID
+	    * i width: width in physical pixels
+	    * i height: height in physical pixels
+	    * d refresh rate: refresh rate
+	    * d preferred scale: scale preferred as per calculations
+	    * ad supported scales: scales supported by this mode
+	    * a{sv} properties: optional properties, including:
+	       - "is-current" (b): the mode is currently active mode
+	       - "is-preferred" (b): the mode is the preferred mode
+	       - "is-interlaced" (b): the mode is an interlaced mode
+	* a{sv} properties: optional properties, including:
+	    - "width-mm" (i): physical width of monitor in millimeters
+	    - "height-mm" (i): physical height of monitor in millimeters
+	    - "is-underscanning" (b): whether underscanning is enabled
+				      (absence of this means underscanning
+				      not being supported)
+	    - "max-screen-size" (ii): the maximum size a screen may have
+				      (absence of this means unlimited screen
+				      size)
+	    - "is-builtin" (b): whether the monitor is built in, e.g. a
+				laptop panel (absence of this means it is
+				not built in)
+	    - "display-name" (s): a human readable display name of the monitor
+
+        Possible mode flags:
+	  1 : preferred mode
+	  2 : current mode
+
+
+	@logical_monitors represent current logical monitor configuration
+
+	* i x: x position
+	* i y: y position
+	* d scale: scale
+	* u transform: transform (see below)
+	* b primary: true if this is the primary logical monitor
+	* a(sss) monitors: monitors displaying this logical monitor
+	    * connector: name of the connector (e.g. DP-1, eDP-1 etc)
+	    * vendor: vendor name
+	    * product: product name
+	    * serial: product serial
+	* a{sv} properties: possibly other properties
+
+	Posisble transform values:
+	  0: normal
+	  1: 90°
+	  2: 180°
+	  3: 270°
+	  4: flipped
+	  5: 90° flipped
+	  6: 180° flipped
+	  7: 270° flipped
+
+
+	@layout_mode current layout mode represents the way logical monitors
+	are layed out on the screen. Possible modes include:
+
+	  1 : physical
+	  2 : logical
+
+	With physical layout mode, each logical monitor has the same dimensions
+	an the monitor modes of the associated monitors assigned to it, no
+	matter what scale is in use.
+
+	With logical mode, the dimension of a logical monitor is the dimension
+	of the monitor mode, divided by the logical monitor scale.
+
+
+	Possible @properties are:
+
+	* "supports-mirroring" (b): FALSE if mirroring not supported; TRUE or not
+	                            present if mirroring is supported.
+	* "layout-mode" (u): Represents in what way logical monitors are laid
+			     out on the screen. The layout mode can be either
+			     of the ones listed below. Absence of this property
+			     means the layout mode cannot be changed, and that
+			     "logical" mode is assumed to be used.
+	    * 1 : logical  - the dimension of a logical monitor is derived from
+			     the monitor modes associated with it, then scaled
+			     using the logical monitor scale.
+	    * 2 : physical - the dimension of a logical monitor is derived from
+			     the monitor modes associated with it.
+	* "supports-changing-layout-mode" (b): True if the layout mode can be
+					       changed. Absence of this means the
+					       layout mode cannot be changed.
+	* "global-scale-required" (b): True if all the logical monitors must
+				       always use the same scale. Absence of
+				       this means logical monitor scales can
+				       differ.
+    -->
+    <method name="GetCurrentState">
+      <arg name="serial" direction="out" type="u" />
+      <arg name="monitors" direction="out" type="a((ssss)a(siiddada{sv})a{sv})" />
+      <arg name="logical_monitors" direction="out" type="a(iiduba(ssss)a{sv})" />
+      <arg name="properties" direction="out" type="a{sv}" />
+    </method>
+
+    <!--
+	ApplyMonitorsConfig:
+	@serial: configuration serial
+	@method: configuration method
+	@logical_monitors: monitors configuration
+	@properties: properties
+
+	@method represents the way the configuration should be handled.
+
+	Possible methods:
+	  0: verify
+	  1: temporary
+	  2: persistent
+
+	@logical_monitors consists of a list of logical monitor configurations.
+	Each logical monitor configuration consists of:
+
+	* i: layout x position
+	* i: layout y position
+	* d: scale
+	* u: transform (see GetCurrentState)
+	* b primary: true if this is the primary logical monitor
+	* a(ssa{sv}): a list of monitors, each consisting of:
+	    * s: connector
+	    * s: monitor mode ID
+	    * a{sv}: monitor properties, including:
+	        - "enable_underscanning" (b): enable monitor underscanning;
+					      may only be set when underscanning
+					      is supported (see GetCurrentState).
+
+	@properties may effect the global monitor configuration state. Possible
+	properties are:
+
+	* "layout-mode" (u): layout mode the passed configuration is in; may
+			     only be set when changing the layout mode is
+			     supported (see GetCurrentState).
+    -->
+    <method name="ApplyMonitorsConfig">
+      <arg name="serial" direction="in" type="u" />
+      <arg name="method" direction="in" type="u" />
+      <arg name="logical_monitors" direction="in" type="a(iiduba(ssa{sv}))" />
+      <arg name="properties" direction="in" type="a{sv}" />
+    </method>
+  </interface>
+</node>

--- a/data/org.gnome.Mutter.RemoteDesktop.xml
+++ b/data/org.gnome.Mutter.RemoteDesktop.xml
@@ -6,6 +6,10 @@
   <!--
       org.gnome.Mutter.RemoteDesktop:
       @short_description: Remote desktop interface
+
+      This API is private and not intended to be used outside of the integrated
+      system that uses libmutter. No compatibility between versions are
+      promised.
   -->
   <interface name="org.gnome.Mutter.RemoteDesktop">
 
@@ -16,6 +20,12 @@
     <method name="CreateSession">
       <arg name="session_path" type="o" direction="out" />
     </method>
+
+    <!--
+        Version:
+        @short_description: API version
+    -->
+    <property name="Version" type="i" access="read" />
 
   </interface>
 

--- a/data/org.gnome.Mutter.RemoteDesktop.xml
+++ b/data/org.gnome.Mutter.RemoteDesktop.xml
@@ -1,0 +1,165 @@
+<!DOCTYPE node PUBLIC
+'-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
+'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<node>
+
+  <!--
+      org.gnome.Mutter.RemoteDesktop:
+      @short_description: Remote desktop interface
+  -->
+  <interface name="org.gnome.Mutter.RemoteDesktop">
+
+    <!--
+	CreateSession:
+	@session_path: Path to the new session object
+    -->
+    <method name="CreateSession">
+      <arg name="session_path" type="o" direction="out" />
+    </method>
+
+  </interface>
+
+  <!--
+       org.gnome.Mutter.RemoteDesktop.Session:
+       @short_description: Remote desktop session
+  -->
+  <interface name="org.gnome.Mutter.RemoteDesktop.Session">
+
+    <!--
+	SessionId:
+
+	An identification string used for identifying a remote desktop session.
+	It can be used to associate screen cast sessions with a remote desktop session.
+    -->
+    <property name="SessionId" type="s" access="read" />
+
+    <!--
+	Start:
+
+	Start the remote desktop session
+    -->
+    <method name="Start" />
+
+    <!--
+	Stop:
+
+	Stop the remote desktop session
+    -->
+    <method name="Stop" />
+
+    <!--
+	Closed:
+
+	The session has closed.
+
+	A session doesn't have to have been started before it may be closed.
+	After it being closed, it can no longer be used.
+    -->
+    <signal name="Closed" />
+
+    <!--
+	NotifyKeyboardKeycode:
+
+	A key identified by a keysym was pressed or released
+     -->
+    <method name="NotifyKeyboardKeycode">
+      <arg name="keycode" type="u" direction="in" />
+      <arg name="state" type="b" direction="in" />
+    </method>
+
+    <!--
+	NotifyKeyboardKeysym:
+
+	A key identified by a keysym was pressed or released
+     -->
+    <method name="NotifyKeyboardKeysym">
+      <arg name="keysym" type="u" direction="in" />
+      <arg name="state" type="b" direction="in" />
+    </method>
+
+    <!--
+	NotifyPointerButton:
+
+	A pointer button was pressed or released
+     -->
+    <method name="NotifyPointerButton">
+      <arg name="button" type="i" direction="in" />
+      <arg name="state" type="b" direction="in" />
+    </method>
+
+    <!--
+	NotifyPointerAxis:
+
+	A smooth pointer axis event notification
+     -->
+    <method name="NotifyPointerAxis">
+      <arg name="dx" type="d" direction="in" />
+      <arg name="dy" type="d" direction="in" />
+    </method>
+    <!--
+	NotifyPointerAxisDiscrete:
+
+	A discrete pointer axis event notification
+     -->
+    <method name="NotifyPointerAxisDiscrete">
+      <arg name="axis" type="u" direction="in" />
+      <arg name="steps" type="i" direction="in" />
+    </method>
+
+    <!--
+	NotifyPointerMotionAbsolute:
+
+	A absolute pointer motion event notification
+     -->
+    <method name="NotifyPointerMotionRelative">
+      <arg name="dx" type="d" direction="in" />
+      <arg name="dy" type="d" direction="in" />
+    </method>
+
+    <!--
+	NotifyPointerMotionAbsolute:
+
+	A absolute pointer motion event notification
+     -->
+    <method name="NotifyPointerMotionAbsolute">
+      <arg name="stream" type="s" direction="in" />
+      <arg name="x" type="d" direction="in" />
+      <arg name="y" type="d" direction="in" />
+    </method>
+
+    <!--
+	NotifyTouchDown:
+
+	A absolute pointer motion event notification
+     -->
+    <method name="NotifyTouchDown">
+      <arg name="stream" type="s" direction="in" />
+      <arg name="slot" type="u" direction="in" />
+      <arg name="x" type="d" direction="in" />
+      <arg name="y" type="d" direction="in" />
+    </method>
+
+    <!--
+	NotifyTouchMotion:
+
+	A absolute pointer motion event notification
+     -->
+    <method name="NotifyTouchMotion">
+      <arg name="stream" type="s" direction="in" />
+      <arg name="slot" type="u" direction="in" />
+      <arg name="x" type="d" direction="in" />
+      <arg name="y" type="d" direction="in" />
+    </method>
+
+    <!--
+	NotifyTouchUp:
+
+	A absolute pointer motion event notification
+     -->
+    <method name="NotifyTouchUp">
+      <arg name="slot" type="u" direction="in" />
+    </method>
+
+  </interface>
+
+</node>

--- a/data/org.gnome.Mutter.ScreenCast.xml
+++ b/data/org.gnome.Mutter.ScreenCast.xml
@@ -6,6 +6,10 @@
   <!--
       org.gnome.Mutter.ScreenCast:
       @short_description: Screen cast interface
+
+      This API is private and not intended to be used outside of the integrated
+      system that uses libmutter. No compatibility between versions are
+      promised.
   -->
   <interface name="org.gnome.Mutter.ScreenCast">
 
@@ -23,6 +27,12 @@
       <arg name="properties" type="a{sv}" direction="in" />
       <arg name="session_path" type="o" direction="out" />
     </method>
+
+    <!--
+        Version:
+        @short_description: API version
+    -->
+    <property name="Version" type="i" access="read" />
 
   </interface>
 

--- a/data/org.gnome.Mutter.ScreenCast.xml
+++ b/data/org.gnome.Mutter.ScreenCast.xml
@@ -1,0 +1,120 @@
+<!DOCTYPE node PUBLIC
+'-//freedesktop//DTD D-BUS Object Introspection 1.0//EN'
+'http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd'>
+<node>
+
+  <!--
+      org.gnome.Mutter.ScreenCast:
+      @short_description: Screen cast interface
+  -->
+  <interface name="org.gnome.Mutter.ScreenCast">
+
+    <!--
+	CreateSession:
+	@properties: Properties
+	@session_path: Path to the new session object
+
+	* "remote-desktop-session-id" (s): The ID of a remote desktop session.
+					   Remote desktop driven screen casts
+					   are started and stopped by the remote
+					   desktop session.
+    -->
+    <method name="CreateSession">
+      <arg name="properties" type="a{sv}" direction="in" />
+      <arg name="session_path" type="o" direction="out" />
+    </method>
+
+  </interface>
+
+  <!--
+       org.gnome.Mutter.ScreenCast.Session:
+       @short_description: Screen cast session
+  -->
+  <interface name="org.gnome.Mutter.ScreenCast.Session">
+
+    <!--
+	Start:
+
+	Start the screen cast session
+    -->
+    <method name="Start" />
+
+    <!--
+	Stop:
+
+	Stop the screen cast session
+    -->
+    <method name="Stop" />
+
+    <!--
+	Closed:
+
+	The session has closed.
+    -->
+    <signal name="Closed" />
+
+    <!--
+	RecordMonitor:
+	@connector: Connector of the monitor to record
+	@properties: Properties
+	@stream_path: Path to the new stream object
+
+	Record a single monitor.
+
+	Available @properties include: (none)
+    -->
+    <method name="RecordMonitor">
+      <arg name="connector" type="s" direction="in" />
+      <arg name="properties" type="a{sv}" direction="in" />
+      <arg name="stream_path" type="o" direction="out" />
+    </method>
+
+    <!--
+	RecordWindow:
+	@properties: Properties used determining what window to select
+	@stream_path: Path to the new stream object
+
+	Record a single window.
+
+	Available @properties include: (none)
+    -->
+    <method name="RecordWindow">
+      <arg name="properties" type="a{sv}" direction="in" />
+      <arg name="stream_path" type="o" direction="out" />
+    </method>
+  </interface>
+
+  <!--
+       org.gnome.Mutter.ScreenCast.Stream:
+       @short_description: Screen cast stream
+  -->
+  <interface name="org.gnome.Mutter.ScreenCast.Stream">
+
+    <!--
+	PipeWireStreamAdded:
+	@short_description: Pipewire stream added
+
+	A signal emitted when PipeWire stream for the screen cast stream has
+	been created. The @node_id corresponds to the PipeWire stream node.
+    -->
+    <signal name="PipeWireStreamAdded">
+      <annotation name="org.gtk.GDBus.C.Name" value="pipewire-stream-added"/>
+      <arg name="node_id" type="u" direction="out" />
+    </signal>
+
+    <!--
+	Parameters:
+	@short_description: Optional stream parameters
+
+	Available parameters include:
+
+	* "position" (ii): Position of the source of the stream in the
+	                   compositor coordinate space.
+	* "size" (ii): Size of the source of the stream in the compositor
+		       coordinate space.
+    -->
+    <property name="Parameters" type="a{sv}" access="read" />
+
+  </interface>
+
+</node>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,4 +8,6 @@ src/appchooserdialog.ui
 src/filechooser.c
 src/screenshotdialog.c
 src/screenshotdialog.ui
+src/screencastdialog.c
+src/screencastdialog.ui
 data/xdg-desktop-portal-gtk.desktop.in.in

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -19,6 +19,7 @@ $(dbus_built_sources): src/Makefile.am.inc
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Access.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Account.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Email.xml \
+	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.ScreenCast.xml \
 	$(NULL)
 
 shell_built_sources = src/shell-dbus.c src/shell-dbus.h
@@ -29,6 +30,7 @@ $(shell_built_sources): src/Makefile.am.inc
 	$(AM_V_GEN) $(GDBUS_CODEGEN)			                \
 	--generate-c-code src/shell-dbus	                        \
 	$(top_srcdir)/data/org.gnome.Mutter.DisplayConfig.xml	        \
+	$(top_srcdir)/data/org.gnome.Mutter.ScreenCast.xml	        \
 	$(top_srcdir)/data/org.gnome.Shell.Screenshot.xml	        \
 	$(top_srcdir)/data/org.gtk.Notifications.xml			\
 	$(top_srcdir)/data/org.gnome.SessionManager.xml		        \
@@ -52,6 +54,7 @@ EXTRA_DIST += \
         src/screenshotdialog.ui                         \
         src/screenshotdialog.css                        \
         src/accountdialog.ui                            \
+        src/screencastdialog.ui                         \
 	$(NULL)
 
 libexec_PROGRAMS = \
@@ -96,6 +99,10 @@ xdg_desktop_portal_gtk_SOURCES = \
         src/gtkbackports.c                      \
 	src/externalwindow.h			\
 	src/externalwindow.c			\
+	src/screencast.c			\
+	src/srceencast.h			\
+	src/screencastdialog.c			\
+	src/screencastdialog.h			\
 	src/displaystatetracker.c		\
 	src/displaystatetracker.h		\
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -103,6 +103,8 @@ xdg_desktop_portal_gtk_SOURCES = \
 	src/srceencast.h			\
 	src/screencastdialog.c			\
 	src/screencastdialog.h			\
+	src/gnomescreencast.c			\
+	src/gnomescreencast.h			\
 	src/displaystatetracker.c		\
 	src/displaystatetracker.h		\
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -20,6 +20,7 @@ $(dbus_built_sources): src/Makefile.am.inc
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Account.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Email.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.ScreenCast.xml \
+	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	$(NULL)
 
 shell_built_sources = src/shell-dbus.c src/shell-dbus.h
@@ -31,6 +32,7 @@ $(shell_built_sources): src/Makefile.am.inc
 	--generate-c-code src/shell-dbus	                        \
 	$(top_srcdir)/data/org.gnome.Mutter.DisplayConfig.xml	        \
 	$(top_srcdir)/data/org.gnome.Mutter.ScreenCast.xml	        \
+	$(top_srcdir)/data/org.gnome.Mutter.RemoteDesktop.xml	        \
 	$(top_srcdir)/data/org.gnome.Shell.Screenshot.xml	        \
 	$(top_srcdir)/data/org.gtk.Notifications.xml			\
 	$(top_srcdir)/data/org.gnome.SessionManager.xml		        \
@@ -56,6 +58,7 @@ EXTRA_DIST += \
         src/accountdialog.ui                            \
         src/screencastwidget.ui                         \
         src/screencastdialog.ui                         \
+        src/remotedesktopdialog.ui                      \
 	$(NULL)
 
 libexec_PROGRAMS = \
@@ -108,6 +111,10 @@ xdg_desktop_portal_gtk_SOURCES = \
 	src/screencastdialog.h			\
 	src/gnomescreencast.c			\
 	src/gnomescreencast.h			\
+	src/remotedesktop.c			\
+	src/remotedesktop.h			\
+	src/remotedesktopdialog.c		\
+	src/remotedesktopdialog.h		\
 	src/displaystatetracker.c		\
 	src/displaystatetracker.h		\
 	$(NULL)

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -27,6 +27,7 @@ CLEANFILES += $(shell_built_sources)
 $(shell_built_sources): src/Makefile.am.inc
 	$(AM_V_GEN) $(GDBUS_CODEGEN)			                \
 	--generate-c-code src/shell-dbus	                        \
+	$(top_srcdir)/data/org.gnome.Mutter.DisplayConfig.xml	        \
 	$(top_srcdir)/data/org.gnome.Shell.Screenshot.xml	        \
 	$(top_srcdir)/data/org.gtk.Notifications.xml			\
 	$(top_srcdir)/data/org.gnome.SessionManager.xml		        \
@@ -92,6 +93,8 @@ xdg_desktop_portal_gtk_SOURCES = \
         src/gtkbackports.c                      \
 	src/externalwindow.h			\
 	src/externalwindow.c			\
+	src/displaystatetracker.c		\
+	src/displaystatetracker.h		\
 	$(NULL)
 
 nodist_xdg_desktop_portal_gtk_SOURCES = \

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -9,6 +9,7 @@ $(dbus_built_sources): src/Makefile.am.inc
 	--generate-c-code src/xdg-desktop-portal-dbus	\
 	--annotate "org.freedesktop.impl.portal.Print.Print()" "org.gtk.GDBus.C.UnixFD" "true" \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Request.xml \
+	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Session.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.FileChooser.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.AppChooser.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Print.xml \
@@ -63,6 +64,8 @@ xdg_desktop_portal_gtk_SOURCES = \
 	src/utils.c				\
 	src/request.h			        \
 	src/request.c			        \
+	src/session.c   			\
+	src/session.h	        		\
 	src/filechooser.h			\
 	src/filechooser.c			\
 	src/appchooser.h			\

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -54,6 +54,7 @@ EXTRA_DIST += \
         src/screenshotdialog.ui                         \
         src/screenshotdialog.css                        \
         src/accountdialog.ui                            \
+        src/screencastwidget.ui                         \
         src/screencastdialog.ui                         \
 	$(NULL)
 
@@ -101,6 +102,8 @@ xdg_desktop_portal_gtk_SOURCES = \
 	src/externalwindow.c			\
 	src/screencast.c			\
 	src/srceencast.h			\
+	src/screencastwidget.c			\
+	src/screencastwidget.h			\
 	src/screencastdialog.c			\
 	src/screencastdialog.h			\
 	src/gnomescreencast.c			\

--- a/src/displaystatetracker.c
+++ b/src/displaystatetracker.c
@@ -1,0 +1,335 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+
+#include "shell-dbus.h"
+#include "displaystatetracker.h"
+
+enum
+{
+  MONITORS_CHANGED,
+
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS];
+
+typedef struct _Monitor
+{
+  char *connector;
+  char *display_name;
+} Monitor;
+
+typedef struct _LogicalMonitor
+{
+  gboolean is_primary;
+  GList *monitors;
+} LogicalMonitor;
+
+struct _DisplayStateTracker
+{
+  GObject parent;
+
+  guint display_config_watch_name_id;
+  GCancellable *cancellable;
+
+  OrgGnomeMutterDisplayConfig *proxy;
+
+  GHashTable *monitors;
+  GList *logical_monitors;
+};
+
+G_DEFINE_TYPE (DisplayStateTracker, display_state_tracker, G_TYPE_OBJECT)
+
+static DisplayStateTracker *_display_state_tracker;
+
+static void
+monitor_free (Monitor *monitor)
+{
+  g_free (monitor->connector);
+  g_free (monitor->display_name);
+  g_free (monitor);
+}
+
+const char *
+monitor_get_connector (Monitor *monitor)
+{
+  return monitor->connector;
+}
+
+const char *
+monitor_get_display_name (Monitor *monitor)
+{
+  return monitor->display_name;
+}
+
+GList *
+logical_monitor_get_monitors (LogicalMonitor *logical_monitor)
+{
+  return logical_monitor->monitors;
+}
+
+gboolean
+logical_monitor_is_primary (LogicalMonitor *logical_monitor)
+{
+  return logical_monitor->is_primary;
+}
+
+GList *
+display_state_tracker_get_logical_monitors (DisplayStateTracker *tracker)
+{
+  return tracker->logical_monitors;
+}
+
+static void
+generate_monitors (DisplayStateTracker *tracker,
+                   GVariant *monitors)
+{
+  GVariantIter monitors_iter;
+  GVariant *monitor_variant;
+
+  g_variant_iter_init (&monitors_iter, monitors);
+  while ((monitor_variant = g_variant_iter_next_value (&monitors_iter)))
+    {
+      Monitor *monitor;
+      char *connector;
+      char *display_name;
+      GVariant *properties;
+
+      g_variant_get (monitor_variant, "((ssss)a(siiddada{sv})@a{sv})",
+                     &connector,
+                     NULL /* vendor */,
+                     NULL /* product */,
+                     NULL /* serial */,
+                     NULL /* modes */,
+                     &properties);
+
+      if (!g_variant_lookup (properties, "display-name", "s", &display_name))
+        display_name = g_strdup (connector);
+
+      monitor = g_new0 (Monitor, 1);
+      *monitor = (Monitor) {
+        .connector = connector,
+        .display_name = display_name
+      };
+
+      g_hash_table_insert (tracker->monitors, connector, monitor);
+
+      g_variant_unref (monitor_variant);
+    }
+}
+
+static void
+generate_logical_monitors (DisplayStateTracker *tracker,
+                           GVariant *logical_monitors)
+{
+  GVariantIter logical_monitors_iter;
+  GVariant *logical_monitor_variant;
+
+  g_variant_iter_init (&logical_monitors_iter, logical_monitors);
+  while ((logical_monitor_variant = g_variant_iter_next_value (&logical_monitors_iter)))
+    {
+      LogicalMonitor *logical_monitor;
+      gboolean is_primary;
+      g_autoptr(GVariantIter) monitors_iter;
+      GVariant *monitor_variant;
+
+      g_variant_get (logical_monitor_variant, "(iiduba(ssss)a{sv})",
+                     NULL /* x */,
+                     NULL /* y */,
+                     NULL /* scale */,
+                     NULL /* transform */,
+                     &is_primary,
+                     &monitors_iter,
+                     NULL /* properties */);
+
+      logical_monitor = g_new0 (LogicalMonitor, 1);
+      *logical_monitor = (LogicalMonitor) {
+        .is_primary = is_primary
+      };
+
+      while ((monitor_variant = g_variant_iter_next_value (monitors_iter)))
+        {
+          g_autofree char *connector = NULL;
+          Monitor *monitor;
+
+          g_variant_get (monitor_variant, "(ssss)",
+                         &connector,
+                         NULL /* vendor */,
+                         NULL /* product */,
+                         NULL /* serial */);
+
+          monitor = g_hash_table_lookup (tracker->monitors, connector);
+
+          logical_monitor->monitors = g_list_append (logical_monitor->monitors, monitor);
+
+          g_variant_unref (monitor_variant);
+        }
+
+      tracker->logical_monitors = g_list_append (tracker->logical_monitors,
+                                                 logical_monitor);
+
+      g_variant_unref (logical_monitor_variant);
+    }
+}
+
+static void
+get_current_state_cb (GObject *source_object,
+                      GAsyncResult *res,
+                      gpointer user_data)
+{
+  DisplayStateTracker *tracker = user_data;
+  g_autoptr(GVariant) monitors = NULL;
+  g_autoptr(GVariant) logical_monitors = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (!org_gnome_mutter_display_config_call_get_current_state_finish (tracker->proxy,
+                                                                      NULL,
+                                                                      &monitors,
+                                                                      &logical_monitors,
+                                                                      NULL /* props */,
+                                                                      res,
+                                                                      &error))
+    {
+      g_warning ("Failed to get current display state: %s", error->message);
+      return;
+    }
+
+  g_list_free_full (tracker->logical_monitors, g_free);
+  tracker->logical_monitors = NULL;
+  g_hash_table_remove_all (tracker->monitors);
+  generate_monitors (tracker, monitors);
+  generate_logical_monitors (tracker, logical_monitors);
+
+  g_signal_emit (tracker, signals[MONITORS_CHANGED], 0);
+}
+
+static void
+sync_state (DisplayStateTracker *tracker)
+{
+  org_gnome_mutter_display_config_call_get_current_state (tracker->proxy,
+                                                          tracker->cancellable,
+                                                          get_current_state_cb,
+                                                          tracker);
+}
+
+static void
+on_monitors_changed (OrgGnomeMutterDisplayConfig *proxy,
+                     DisplayStateTracker *tracker)
+{
+  sync_state (tracker);
+}
+
+static void
+on_display_config_proxy_acquired (GObject      *object,
+                                  GAsyncResult *result,
+                                  gpointer      user_data)
+{
+  DisplayStateTracker *tracker = user_data;
+  OrgGnomeMutterDisplayConfig *proxy;
+  g_autoptr(GError) error = NULL;
+
+  proxy = org_gnome_mutter_display_config_proxy_new_for_bus_finish (result, &error);
+  if (!proxy)
+    {
+      g_warning ("Failed to acquire org.gnome.Mutter.DisplayConfig proxy: %s",
+                 error->message);
+      return;
+    }
+
+  tracker->proxy = proxy;
+
+  g_signal_connect (proxy, "monitors-changed",
+                    G_CALLBACK (on_monitors_changed),
+                    tracker);
+
+  sync_state (tracker);
+}
+
+static void
+on_display_config_name_appeared (GDBusConnection *connection,
+                                 const char *name,
+                                 const char *name_owner,
+                                 gpointer user_data)
+{
+  DisplayStateTracker *tracker = user_data;
+
+  org_gnome_mutter_display_config_proxy_new_for_bus (G_BUS_TYPE_SESSION,
+                                                     G_DBUS_PROXY_FLAGS_NONE,
+                                                     "org.gnome.Mutter.DisplayConfig",
+                                                     "/org/gnome/Mutter/DisplayConfig",
+                                                     tracker->cancellable,
+                                                     on_display_config_proxy_acquired,
+                                                     tracker);
+}
+
+static void
+on_display_config_name_vanished (GDBusConnection *connection,
+                                 const char *name,
+                                 gpointer user_data)
+{
+  DisplayStateTracker *tracker = user_data;
+
+  if (tracker->cancellable)
+    {
+      g_cancellable_cancel (tracker->cancellable);
+      g_clear_object (&tracker->cancellable);
+    }
+}
+
+DisplayStateTracker *
+display_state_tracker_get (void)
+{
+  DisplayStateTracker *tracker;
+
+  if (_display_state_tracker)
+    return _display_state_tracker;
+
+  tracker = g_object_new (display_state_tracker_get_type (), NULL);
+  tracker->display_config_watch_name_id =
+    g_bus_watch_name (G_BUS_TYPE_SESSION,
+                      "org.gnome.Mutter.DisplayConfig",
+                      G_BUS_NAME_WATCHER_FLAGS_NONE,
+                      on_display_config_name_appeared,
+                      on_display_config_name_vanished,
+                      tracker, NULL);
+
+  _display_state_tracker = tracker;
+  return tracker;
+}
+
+static void
+display_state_tracker_init (DisplayStateTracker *tracker)
+{
+  tracker->monitors = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                             NULL, (GDestroyNotify) monitor_free);
+}
+
+static void
+display_state_tracker_class_init (DisplayStateTrackerClass *klass)
+{
+  signals[MONITORS_CHANGED] = g_signal_new ("monitors-changed",
+                                            G_TYPE_FROM_CLASS (klass),
+                                            G_SIGNAL_RUN_LAST,
+                                            0,
+                                            NULL, NULL, NULL,
+                                            G_TYPE_NONE, 0);
+}

--- a/src/displaystatetracker.h
+++ b/src/displaystatetracker.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <glib-object.h>
+
+typedef struct _Monitor Monitor;
+typedef struct _LogicalMonitor LogicalMonitor;
+
+G_DECLARE_FINAL_TYPE (DisplayStateTracker, display_state_tracker,
+                      DISPLAY, STATE_TRACKER, GObject)
+
+const char * monitor_get_connector (Monitor *monitor);
+
+const char * monitor_get_display_name (Monitor *monitor);
+
+GList * logical_monitor_get_monitors (LogicalMonitor *logical_monitor);
+
+gboolean logical_monitor_is_primary (LogicalMonitor *logical_monitor);
+
+GList * display_state_tracker_get_logical_monitors (DisplayStateTracker *tracker);
+
+DisplayStateTracker * display_state_tracker_get (void);

--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -22,6 +22,8 @@
 
 #include <stdint.h>
 
+#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 1
+
 enum
 {
   STREAM_SIGNAL_READY,
@@ -485,6 +487,7 @@ gnome_screen_cast_name_appeared (GDBusConnection *connection,
 {
   GnomeScreenCast *gnome_screen_cast = user_data;
   g_autoptr(GError) error = NULL;
+  int api_version;
 
   gnome_screen_cast->proxy =
     org_gnome_mutter_screen_cast_proxy_new_sync (connection,
@@ -497,6 +500,15 @@ gnome_screen_cast_name_appeared (GDBusConnection *connection,
     {
       g_warning ("Failed to acquire org.gnome.Mutter.ScreenCast proxy: %s",
                  error->message);
+      return;
+    }
+
+  api_version =
+    org_gnome_mutter_screen_cast_get_version (gnome_screen_cast->proxy);
+  if (api_version != SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION)
+    {
+      g_warning ("org.gnome.Mutter.ScreenCast API version not compatible");
+      g_clear_object (&gnome_screen_cast->proxy);
       return;
     }
 

--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -194,6 +194,23 @@ gnome_screen_cast_stream_class_init (GnomeScreenCastStreamClass *klass)
                                                       G_TYPE_NONE, 0);
 }
 
+const char *
+gnome_screen_cast_session_get_stream_path_from_id (GnomeScreenCastSession *gnome_screen_cast_session,
+                                                   uint32_t stream_id)
+{
+  GList *l;
+
+  for (l = gnome_screen_cast_session->streams; l; l = l->next)
+    {
+      GnomeScreenCastStream *stream = l->data;
+
+      if (stream->pipewire_node_id == stream_id)
+        return stream->path;
+    }
+
+  return NULL;
+}
+
 void
 gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gnome_screen_cast_session,
                                                  GVariantBuilder *streams_builder)

--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -412,6 +412,7 @@ on_mutter_session_closed (OrgGnomeMutterScreenCastSession *session_proxy,
 
 GnomeScreenCastSession *
 gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
+                                  const char *remote_desktop_session_id,
                                   GError **error)
 {
   GVariantBuilder properties_builder;
@@ -422,6 +423,12 @@ gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
   GnomeScreenCastSession *gnome_screen_cast_session;
 
   g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  if (remote_desktop_session_id)
+    {
+      g_variant_builder_add (&properties_builder, "{sv}",
+                             "remote-desktop-session-id",
+                             g_variant_new_string (remote_desktop_session_id));
+    }
   properties = g_variant_builder_end (&properties_builder);
   if (!org_gnome_mutter_screen_cast_call_create_session_sync (gnome_screen_cast->proxy,
                                                               properties,

--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -1,0 +1,473 @@
+/*
+ * Copyright © 2017-2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "gnomescreencast.h"
+#include "shell-dbus.h"
+
+#include <stdint.h>
+
+enum
+{
+  STREAM_SIGNAL_READY,
+
+  N_STREAM_SIGNALS
+};
+
+guint stream_signals[N_STREAM_SIGNALS];
+
+enum
+{
+  SESSION_SIGNAL_READY,
+  SESSION_SIGNAL_CLOSED,
+
+  N_SESSION_SIGNALS
+};
+
+guint session_signals[N_SESSION_SIGNALS];
+
+enum
+{
+  ENABLED,
+  DISABLED,
+
+  N_SIGNALS
+};
+
+guint signals[N_SIGNALS];
+
+typedef struct _GnomeScreenCastStream
+{
+  GObject parent;
+
+  GnomeScreenCastSession *session;
+
+  char *path;
+  OrgGnomeMutterScreenCastStream *proxy;
+
+  uint32_t pipewire_node_id;
+
+  gboolean has_position;
+  int x;
+  int y;
+
+  gboolean has_size;
+  int width;
+  int height;
+} GnomeScreenCastStream;
+
+typedef struct _GnomeScreenCastStreamClass
+{
+  GObjectClass parent_class;
+} GnomeScreenCastStreamClass;
+
+typedef struct _GnomeScreenCastSession
+{
+  GObject parent;
+
+  char *path;
+  OrgGnomeMutterScreenCastSession *proxy;
+  gulong closed_handler_id;
+
+  GList *streams;
+  int n_needed_stream_node_ids;
+} GnomeScreenCastSession;
+
+typedef struct _GnomeScreenCastSessionClass
+{
+  GObjectClass parent_class;
+} GnomeScreenCastSessionClass;
+
+typedef struct _GnomeScreenCast
+{
+  GObject parent;
+
+  guint screen_cast_name_watch;
+  OrgGnomeMutterScreenCast *proxy;
+} GnomeScreenCast;
+
+typedef struct _GnomeScreenCastClass
+{
+  GObjectClass parent_class;
+} GnomeScreenCastClass;
+
+static GType gnome_screen_cast_stream_get_type (void);
+G_DEFINE_TYPE (GnomeScreenCastStream, gnome_screen_cast_stream, G_TYPE_OBJECT)
+
+static GType gnome_screen_cast_session_get_type (void);
+G_DEFINE_TYPE (GnomeScreenCastSession, gnome_screen_cast_session, G_TYPE_OBJECT)
+
+static GType gnome_screen_cast_get_type (void);
+G_DEFINE_TYPE (GnomeScreenCast, gnome_screen_cast, G_TYPE_OBJECT)
+
+uint32_t
+gnome_screen_cast_stream_get_pipewire_node_id (GnomeScreenCastStream *stream)
+{
+  return stream->pipewire_node_id;
+}
+
+gboolean
+gnome_screen_cast_stream_get_position (GnomeScreenCastStream *stream,
+                                       int *x,
+                                       int *y)
+{
+  if (!stream->has_position)
+    return FALSE;
+
+  *x = stream->x;
+  *y = stream->y;
+
+  return TRUE;
+}
+
+gboolean
+gnome_screen_cast_stream_get_size (GnomeScreenCastStream *stream,
+                                   int *width,
+                                   int *height)
+{
+  if (!stream->has_size)
+    return FALSE;
+
+  *width = stream->width;
+  *height = stream->height;
+
+  return TRUE;
+}
+
+static void
+gnome_screen_cast_stream_finalize (GObject *object)
+{
+  GnomeScreenCastStream *stream = (GnomeScreenCastStream *)object;
+
+  g_clear_object (&stream->proxy);
+  g_free (stream->path);
+
+  G_OBJECT_CLASS (gnome_screen_cast_stream_parent_class)->finalize (object);
+}
+
+static void
+on_pipewire_stream_added (OrgGnomeMutterScreenCastStream *stream_proxy,
+                          unsigned int arg_node_id,
+                          GnomeScreenCastStream *stream)
+{
+  stream->pipewire_node_id = arg_node_id;
+  g_signal_emit (stream, stream_signals[STREAM_SIGNAL_READY], 0);
+
+  stream->session->n_needed_stream_node_ids--;
+  if (stream->session->n_needed_stream_node_ids == 0)
+    g_signal_emit (stream->session, session_signals[SESSION_SIGNAL_READY], 0);
+}
+
+static void
+gnome_screen_cast_stream_init (GnomeScreenCastStream *stream)
+{
+}
+
+static void
+gnome_screen_cast_stream_class_init (GnomeScreenCastStreamClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = gnome_screen_cast_stream_finalize;
+
+  stream_signals[STREAM_SIGNAL_READY] = g_signal_new ("ready",
+                                                      G_TYPE_FROM_CLASS (klass),
+                                                      G_SIGNAL_RUN_LAST,
+                                                      0,
+                                                      NULL, NULL,
+                                                      NULL,
+                                                      G_TYPE_NONE, 0);
+}
+
+GList *
+gnome_screen_cast_session_get_streams (GnomeScreenCastSession *gnome_screen_cast_session)
+{
+  return gnome_screen_cast_session->streams;
+}
+
+gboolean
+gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_cast_session,
+                                          const char *connector,
+                                          GError **error)
+{
+  OrgGnomeMutterScreenCastSession *session_proxy =
+    gnome_screen_cast_session->proxy;
+  GVariantBuilder properties_builder;
+  GVariant *properties;
+  g_autofree char *stream_path = NULL;
+  GDBusConnection *connection;
+  OrgGnomeMutterScreenCastStream *stream_proxy;
+  GnomeScreenCastStream *stream;
+  GVariant *parameters;
+
+  g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  properties = g_variant_builder_end (&properties_builder);
+
+  if (!org_gnome_mutter_screen_cast_session_call_record_monitor_sync (session_proxy,
+                                                                      connector,
+                                                                      properties,
+                                                                      &stream_path,
+                                                                      NULL,
+                                                                      error))
+    return FALSE;
+
+  connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (session_proxy));
+  stream_proxy =
+    org_gnome_mutter_screen_cast_stream_proxy_new_sync (connection,
+                                                        G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                        "org.gnome.Mutter.ScreenCast",
+                                                        stream_path,
+                                                        NULL,
+                                                        error);
+  if (!stream_proxy)
+    return FALSE;
+
+  stream = g_object_new (gnome_screen_cast_stream_get_type (), NULL);
+  stream->session = gnome_screen_cast_session;
+  stream->path = g_strdup (stream_path);
+  stream->proxy = stream_proxy;
+
+  parameters = org_gnome_mutter_screen_cast_stream_get_parameters (stream->proxy);
+  if (parameters)
+    {
+      if (g_variant_lookup (parameters, "position", "(ii)",
+                            &stream->x, &stream->y))
+        stream->has_position = TRUE;
+      if (g_variant_lookup (parameters, "size", "(ii)",
+                            &stream->width, &stream->height))
+        stream->has_size = TRUE;
+    }
+  else
+    {
+      g_warning ("Screen cast stream %s missing parameters",
+                 stream->path);
+    }
+
+  g_signal_connect (stream_proxy, "pipewire-stream-added",
+                    G_CALLBACK (on_pipewire_stream_added),
+                    stream);
+
+  gnome_screen_cast_session->streams =
+    g_list_prepend (gnome_screen_cast_session->streams, stream);
+  gnome_screen_cast_session->n_needed_stream_node_ids++;
+
+  return TRUE;
+}
+
+gboolean
+gnome_screen_cast_session_stop (GnomeScreenCastSession *gnome_screen_cast_session,
+                                GError **error)
+{
+  OrgGnomeMutterScreenCastSession *session_proxy =
+    gnome_screen_cast_session->proxy;
+
+  g_signal_handler_disconnect (gnome_screen_cast_session->proxy,
+                               gnome_screen_cast_session->closed_handler_id);
+
+  if (!org_gnome_mutter_screen_cast_session_call_stop_sync (session_proxy,
+                                                            NULL,
+                                                            error))
+    return FALSE;
+
+  return TRUE;
+}
+
+gboolean
+gnome_screen_cast_session_start (GnomeScreenCastSession *gnome_screen_cast_session,
+                                 GError **error)
+{
+  OrgGnomeMutterScreenCastSession *session_proxy =
+    gnome_screen_cast_session->proxy;
+
+  if (!org_gnome_mutter_screen_cast_session_call_start_sync (session_proxy,
+                                                             NULL,
+                                                             error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+gnome_screen_cast_session_finalize (GObject *object)
+{
+  GnomeScreenCastSession *session = (GnomeScreenCastSession *)object;
+
+  g_list_free_full (session->streams, g_object_unref);
+  g_clear_object (&session->proxy);
+  g_free (session->path);
+
+  G_OBJECT_CLASS (gnome_screen_cast_session_parent_class)->finalize (object);
+}
+
+static void
+gnome_screen_cast_session_init (GnomeScreenCastSession *gnome_screen_cast_session)
+{
+}
+
+static void
+gnome_screen_cast_session_class_init (GnomeScreenCastSessionClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+  object_class->finalize = gnome_screen_cast_session_finalize;
+
+  session_signals[SESSION_SIGNAL_READY] = g_signal_new ("ready",
+                                                        G_TYPE_FROM_CLASS (klass),
+                                                        G_SIGNAL_RUN_LAST,
+                                                        0,
+                                                        NULL, NULL,
+                                                        NULL,
+                                                        G_TYPE_NONE, 0);
+  session_signals[SESSION_SIGNAL_CLOSED] = g_signal_new ("closed",
+                                                         G_TYPE_FROM_CLASS (klass),
+                                                         G_SIGNAL_RUN_LAST,
+                                                         0,
+                                                         NULL, NULL,
+                                                         NULL,
+                                                         G_TYPE_NONE, 0);
+}
+
+static void
+on_mutter_session_closed (OrgGnomeMutterScreenCastSession *session_proxy,
+                          GnomeScreenCastSession *gnome_screen_cast_session)
+{
+  g_signal_emit (gnome_screen_cast_session,
+                 session_signals[SESSION_SIGNAL_CLOSED], 0);
+}
+
+GnomeScreenCastSession *
+gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
+                                  GError **error)
+{
+  GVariantBuilder properties_builder;
+  GVariant *properties;
+  g_autofree char *session_path = NULL;
+  GDBusConnection *connection;
+  OrgGnomeMutterScreenCastSession *session_proxy;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+
+  g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  properties = g_variant_builder_end (&properties_builder);
+  if (!org_gnome_mutter_screen_cast_call_create_session_sync (gnome_screen_cast->proxy,
+                                                              properties,
+                                                              &session_path,
+                                                              NULL,
+                                                              error))
+    return NULL;
+
+  connection = g_dbus_proxy_get_connection (G_DBUS_PROXY (gnome_screen_cast->proxy));
+  session_proxy =
+    org_gnome_mutter_screen_cast_session_proxy_new_sync (connection,
+                                                         G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                         "org.gnome.Mutter.ScreenCast",
+                                                         session_path,
+                                                         NULL,
+                                                         error);
+  if (!session_proxy)
+    return NULL;
+
+  gnome_screen_cast_session =
+    g_object_new (gnome_screen_cast_session_get_type (), NULL);
+  gnome_screen_cast_session->path = g_steal_pointer (&session_path);
+  gnome_screen_cast_session->proxy = g_steal_pointer (&session_proxy);
+  gnome_screen_cast_session->closed_handler_id =
+    g_signal_connect (gnome_screen_cast_session->proxy,
+                      "closed", G_CALLBACK (on_mutter_session_closed),
+                      gnome_screen_cast_session);
+
+  return gnome_screen_cast_session;
+}
+
+static void
+gnome_screen_cast_name_appeared (GDBusConnection *connection,
+                                 const char *name,
+                                 const char *name_owner,
+                                 gpointer user_data)
+{
+  GnomeScreenCast *gnome_screen_cast = user_data;
+  g_autoptr(GError) error = NULL;
+
+  gnome_screen_cast->proxy =
+    org_gnome_mutter_screen_cast_proxy_new_sync (connection,
+                                                 G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                 "org.gnome.Mutter.ScreenCast",
+                                                 "/org/gnome/Mutter/ScreenCast",
+                                                 NULL,
+                                                 &error);
+  if (!gnome_screen_cast->proxy)
+    {
+      g_warning ("Failed to acquire org.gnome.Mutter.ScreenCast proxy: %s",
+                 error->message);
+      return;
+    }
+
+  g_signal_emit (gnome_screen_cast, signals[ENABLED], 0);
+}
+
+static void
+gnome_screen_cast_name_vanished (GDBusConnection *connection,
+                                 const char *name,
+                                 gpointer user_data)
+{
+  GnomeScreenCast *gnome_screen_cast = user_data;
+
+  g_clear_object (&gnome_screen_cast->proxy);
+
+  g_signal_emit (gnome_screen_cast, signals[DISABLED], 0);
+}
+
+static void
+gnome_screen_cast_init (GnomeScreenCast *gnome_screen_cast)
+{
+}
+
+static void
+gnome_screen_cast_class_init (GnomeScreenCastClass *klass)
+{
+  signals[ENABLED] = g_signal_new ("enabled",
+                                   G_TYPE_FROM_CLASS (klass),
+                                   G_SIGNAL_RUN_LAST,
+                                   0,
+                                   NULL, NULL,
+                                   NULL,
+                                   G_TYPE_NONE, 0);
+  signals[DISABLED] = g_signal_new ("disabled",
+                                    G_TYPE_FROM_CLASS (klass),
+                                    G_SIGNAL_RUN_LAST,
+                                    0,
+                                    NULL, NULL,
+                                    NULL,
+                                    G_TYPE_NONE, 0);
+}
+
+GnomeScreenCast *
+gnome_screen_cast_new (GDBusConnection *connection)
+{
+  GnomeScreenCast *gnome_screen_cast;
+
+  gnome_screen_cast = g_object_new (gnome_screen_cast_get_type (), NULL);
+  gnome_screen_cast->screen_cast_name_watch =
+    g_bus_watch_name (G_BUS_TYPE_SESSION,
+                      "org.gnome.Mutter.ScreenCast",
+                      G_BUS_NAME_WATCHER_FLAGS_NONE,
+                      gnome_screen_cast_name_appeared,
+                      gnome_screen_cast_name_vanished,
+                      gnome_screen_cast,
+                      NULL);
+
+  return gnome_screen_cast;
+}

--- a/src/gnomescreencast.h
+++ b/src/gnomescreencast.h
@@ -26,6 +26,9 @@ typedef struct _GnomeScreenCast GnomeScreenCast;
 typedef struct _GnomeScreenCastSession GnomeScreenCastSession;
 typedef struct _GnomeScreenCastStream GnomeScreenCastStream;
 
+const char * gnome_screen_cast_session_get_stream_path_from_id (GnomeScreenCastSession *gnome_screen_cast_session,
+                                                                uint32_t stream_id);
+
 void gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gnome_screen_cast_session,
                                                       GVariantBuilder *streams_builder);
 

--- a/src/gnomescreencast.h
+++ b/src/gnomescreencast.h
@@ -26,21 +26,12 @@ typedef struct _GnomeScreenCast GnomeScreenCast;
 typedef struct _GnomeScreenCastSession GnomeScreenCastSession;
 typedef struct _GnomeScreenCastStream GnomeScreenCastStream;
 
-uint32_t gnome_screen_cast_stream_get_pipewire_node_id (GnomeScreenCastStream *stream);
+void gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gnome_screen_cast_session,
+                                                      GVariantBuilder *streams_builder);
 
-gboolean gnome_screen_cast_stream_get_position (GnomeScreenCastStream *stream,
-                                                int *x,
-                                                int *y);
-
-gboolean gnome_screen_cast_stream_get_size (GnomeScreenCastStream *stream,
-                                            int *width,
-                                            int *height);
-
-GList *gnome_screen_cast_session_get_streams (GnomeScreenCastSession *gnome_screen_cast_session);
-
-gboolean gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_cast_session,
-                                                   const char *connector,
-                                                   GError **error);
+gboolean gnome_screen_cast_session_record_selections (GnomeScreenCastSession *gnome_screen_cast_session,
+                                                      GVariant *selections,
+                                                      GError **error);
 
 gboolean gnome_screen_cast_session_stop (GnomeScreenCastSession *gnome_screen_cast_session,
                                          GError **error);

--- a/src/gnomescreencast.h
+++ b/src/gnomescreencast.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gio/gio.h>
+#include <stdint.h>
+
+typedef struct _GnomeScreenCast GnomeScreenCast;
+typedef struct _GnomeScreenCastSession GnomeScreenCastSession;
+typedef struct _GnomeScreenCastStream GnomeScreenCastStream;
+
+uint32_t gnome_screen_cast_stream_get_pipewire_node_id (GnomeScreenCastStream *stream);
+
+gboolean gnome_screen_cast_stream_get_position (GnomeScreenCastStream *stream,
+                                                int *x,
+                                                int *y);
+
+gboolean gnome_screen_cast_stream_get_size (GnomeScreenCastStream *stream,
+                                            int *width,
+                                            int *height);
+
+GList *gnome_screen_cast_session_get_streams (GnomeScreenCastSession *gnome_screen_cast_session);
+
+gboolean gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_cast_session,
+                                                   const char *connector,
+                                                   GError **error);
+
+gboolean gnome_screen_cast_session_stop (GnomeScreenCastSession *gnome_screen_cast_session,
+                                         GError **error);
+
+gboolean gnome_screen_cast_session_start (GnomeScreenCastSession *gnome_screen_cast_session,
+                                          GError **error);
+
+GnomeScreenCastSession *gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
+                                                          GError **error);
+
+GnomeScreenCast *gnome_screen_cast_new (GDBusConnection *connection);

--- a/src/gnomescreencast.h
+++ b/src/gnomescreencast.h
@@ -40,6 +40,7 @@ gboolean gnome_screen_cast_session_start (GnomeScreenCastSession *gnome_screen_c
                                           GError **error);
 
 GnomeScreenCastSession *gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
+                                                          const char *remote_desktop_session_id,
                                                           GError **error);
 
 GnomeScreenCast *gnome_screen_cast_new (GDBusConnection *connection);

--- a/src/remotedesktop.c
+++ b/src/remotedesktop.c
@@ -1,0 +1,994 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <stdint.h>
+
+#include "xdg-desktop-portal-dbus.h"
+#include "shell-dbus.h"
+
+#include "remotedesktop.h"
+#include "remotedesktopdialog.h"
+#include "screencastdialog.h"
+#include "gnomescreencast.h"
+#include "externalwindow.h"
+#include "request.h"
+#include "session.h"
+#include "utils.h"
+
+typedef struct _RemoteDesktopDialogHandle RemoteDesktopDialogHandle;
+
+typedef struct _RemoteDesktopSession
+{
+  Session parent;
+
+  char *parent_window;
+  char *mutter_session_path;
+  OrgGnomeMutterRemoteDesktopSession *mutter_session_proxy;
+  gulong closed_handler_id;
+
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  gulong session_ready_handler_id;
+
+  struct {
+    RemoteDesktopDeviceType device_types;
+
+    struct {
+      gboolean enable;
+      gboolean multiple;
+    } screen_cast;
+  } select;
+
+  struct {
+    RemoteDesktopDeviceType device_types;
+  } shared;
+
+  GDBusMethodInvocation *start_invocation;
+  RemoteDesktopDialogHandle *dialog_handle;
+} RemoteDesktopSession;
+
+typedef struct _RemoteDesktopSessionClass
+{
+  SessionClass parent_class;
+} RemoteDesktopSessionClass;
+
+typedef struct _RemoteDesktopDialogHandle
+{
+  Request *request;
+  RemoteDesktopSession *session;
+
+  GtkWidget *dialog;
+  ExternalWindow *external_parent;
+
+  int response;
+} RemoteDesktopDialogHandle;
+
+static GDBusConnection *impl_connection;
+static guint remote_desktop_name_watch;
+static GDBusInterfaceSkeleton *impl;
+static OrgGnomeMutterRemoteDesktop *remote_desktop;
+static GnomeScreenCast *gnome_screen_cast;
+
+GType remote_desktop_session_get_type (void);
+G_DEFINE_TYPE (RemoteDesktopSession, remote_desktop_session, session_get_type ())
+
+static void
+start_done (RemoteDesktopSession *session);
+
+static gboolean
+start_session (RemoteDesktopSession *session,
+               GVariant *selections,
+               GError **error);
+
+static void
+cancel_start_session (RemoteDesktopSession *session,
+                      int response);
+
+gboolean
+is_remote_desktop_session (Session *session)
+{
+  return G_TYPE_CHECK_INSTANCE_TYPE (session, remote_desktop_session_get_type ());
+}
+
+void
+remote_desktop_session_sources_selected (RemoteDesktopSession *session,
+                                         gboolean multiple)
+{
+  session->select.screen_cast.enable = TRUE;
+  session->select.screen_cast.multiple = multiple;
+}
+
+static void
+remote_desktop_dialog_handle_free (RemoteDesktopDialogHandle *dialog_handle)
+{
+  g_clear_pointer (&dialog_handle->dialog, gtk_widget_destroy);
+  g_clear_object (&dialog_handle->external_parent);
+  g_object_unref (dialog_handle->request);
+
+  g_free (dialog_handle);
+}
+
+static void
+remote_desktop_dialog_handle_close (RemoteDesktopDialogHandle *dialog_handle)
+{
+  remote_desktop_dialog_handle_free (dialog_handle);
+}
+
+static gboolean
+handle_close (XdpImplRequest *object,
+              GDBusMethodInvocation *invocation,
+              RemoteDesktopDialogHandle *dialog_handle)
+{
+  cancel_start_session (dialog_handle->session, 2);
+
+  remote_desktop_dialog_handle_close (dialog_handle);
+
+  return FALSE;
+}
+
+static void
+remote_desktop_dialog_done (GtkWidget *widget,
+                            int dialog_response,
+                            GVariant *selections,
+                            RemoteDesktopDialogHandle *dialog_handle)
+{
+  int response;
+
+  switch (dialog_response)
+    {
+    default:
+      g_warning ("Unexpected response: %d", dialog_response);
+      /* Fall through */
+    case GTK_RESPONSE_DELETE_EVENT:
+      response = 2;
+      break;
+
+    case GTK_RESPONSE_CANCEL:
+      response = 1;
+      break;
+
+    case GTK_RESPONSE_OK:
+      response = 0;
+      break;
+    }
+
+  if (response == 0)
+    {
+      g_autoptr(GError) error = NULL;
+
+      if (!start_session (dialog_handle->session, selections, &error))
+        {
+          g_warning ("Failed to start session: %s", error->message);
+          response = 2;
+        }
+    }
+
+  if (response != 0)
+    cancel_start_session (dialog_handle->session, response);
+}
+
+static RemoteDesktopDialogHandle *
+create_remote_desktop_dialog (RemoteDesktopSession *session,
+                              GDBusMethodInvocation *invocation,
+                              Request *request,
+                              const char *parent_window)
+{
+  RemoteDesktopDialogHandle *dialog_handle;
+  ExternalWindow *external_parent;
+  GdkScreen *screen;
+  GdkDisplay *display;
+  GtkWidget *fake_parent;
+  GtkWidget *dialog;
+
+  if (parent_window)
+    {
+      external_parent = create_external_window_from_handle (parent_window);
+      if (!external_parent)
+        g_warning ("Failed to associate portal window with parent window %s",
+                   parent_window);
+    }
+  else
+    {
+      external_parent = NULL;
+    }
+
+  if (external_parent)
+    display = external_window_get_display (external_parent);
+  else
+    display = gdk_display_get_default ();
+  screen = gdk_display_get_default_screen (display);
+  fake_parent = g_object_new (GTK_TYPE_WINDOW,
+                              "type", GTK_WINDOW_TOPLEVEL,
+                              "screen", screen,
+                              NULL);
+  g_object_ref_sink (fake_parent);
+
+  dialog =
+    GTK_WIDGET (remote_desktop_dialog_new (request->app_id,
+                                           session->select.device_types,
+                                           session->select.screen_cast.enable,
+                                           session->select.screen_cast.multiple));
+  gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
+  gtk_window_set_modal (GTK_WINDOW (dialog), TRUE);
+
+  dialog_handle = g_new0 (RemoteDesktopDialogHandle, 1);
+  dialog_handle->session = session;
+  dialog_handle->request = g_object_ref (request);
+  dialog_handle->external_parent = external_parent;
+  dialog_handle->dialog = dialog;
+
+  g_signal_connect (request, "handle-close",
+                    G_CALLBACK (handle_close), dialog_handle);
+
+  g_signal_connect (dialog, "done",
+                    G_CALLBACK (remote_desktop_dialog_done), dialog_handle);
+
+  gtk_widget_realize (dialog);
+
+  if (external_parent)
+    external_window_set_parent_of (external_parent, gtk_widget_get_window (dialog));
+
+  gtk_widget_show (dialog);
+
+  return dialog_handle;
+}
+
+static void
+on_mutter_session_closed (OrgGnomeMutterRemoteDesktopSession *mutter_session_proxy,
+                          RemoteDesktopSession *remote_desktop_session)
+{
+  session_close ((Session *)remote_desktop_session);
+}
+
+static RemoteDesktopSession *
+remote_desktop_session_new (const char *app_id,
+                            const char *session_handle,
+                            const char *mutter_session_path,
+                            OrgGnomeMutterRemoteDesktopSession *mutter_session_proxy)
+{
+  RemoteDesktopSession *remote_desktop_session;
+
+  remote_desktop_session = g_object_new (remote_desktop_session_get_type (),
+                                         "id", session_handle,
+                                         NULL);
+  remote_desktop_session->mutter_session_path =
+    g_strdup (mutter_session_path);
+  remote_desktop_session->mutter_session_proxy =
+    g_object_ref (mutter_session_proxy);
+
+  remote_desktop_session->closed_handler_id =
+    g_signal_connect (remote_desktop_session->mutter_session_proxy,
+                      "closed", G_CALLBACK (on_mutter_session_closed),
+                      remote_desktop_session);
+
+  return remote_desktop_session;
+}
+
+static gboolean
+handle_create_session (XdpImplRemoteDesktop *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char *arg_session_handle,
+                       const char *arg_app_id,
+                       GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  g_autofree char *mutter_session_path = NULL;
+  g_autoptr(GError) error = NULL;
+  int response;
+  OrgGnomeMutterRemoteDesktopSession *mutter_session_proxy;
+  Session *session;
+  GVariantBuilder results_builder;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  if (!org_gnome_mutter_remote_desktop_call_create_session_sync (remote_desktop,
+                                                                 &mutter_session_path,
+                                                                 NULL,
+                                                                 &error))
+    {
+      g_warning ("Failed to create remote desktop session: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  mutter_session_proxy =
+    org_gnome_mutter_remote_desktop_session_proxy_new_sync (impl_connection,
+                                                            G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                            "org.gnome.Mutter.RemoteDesktop",
+                                                            mutter_session_path,
+                                                            NULL,
+                                                            &error);
+  if (!mutter_session_proxy)
+    {
+      g_warning ("Failed to get remote desktop session proxy: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  session = (Session *)remote_desktop_session_new (arg_app_id,
+                                                   arg_session_handle,
+                                                   mutter_session_path,
+                                                   mutter_session_proxy);
+
+  if (!session_export (session,
+                       g_dbus_method_invocation_get_connection (invocation),
+                       &error))
+    {
+      g_clear_object (&session);
+      g_warning ("Failed to create remote desktop session: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  response = 0;
+
+out:
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_remote_desktop_complete_create_session (object,
+                                                   invocation,
+                                                   response,
+                                                   g_variant_builder_end (&results_builder));
+
+  g_clear_object (&mutter_session_proxy);
+
+  return TRUE;
+}
+
+static gboolean
+handle_select_devices (XdpImplRemoteDesktop *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char *arg_session_handle,
+                       const char *arg_app_id,
+                       GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  RemoteDesktopSession *remote_desktop_session;
+  int response;
+  uint32_t device_types;
+  GVariantBuilder results_builder;
+  GVariant *results;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  if (!remote_desktop_session)
+    {
+      g_warning ("Tried to select sources on non-existing %s", arg_session_handle);
+      response = 2;
+      goto out;
+    }
+
+  if (!g_variant_lookup (arg_options, "types", "u", &device_types))
+    device_types = REMOTE_DESKTOP_DEVICE_TYPE_ALL;
+
+  remote_desktop_session->select.device_types = device_types;
+  response = 0;
+
+out:
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  results = g_variant_builder_end (&results_builder);
+  xdp_impl_remote_desktop_complete_select_devices (object, invocation,
+                                                   response, results);
+
+  return TRUE;
+}
+
+static void
+start_done (RemoteDesktopSession *remote_desktop_session)
+{
+  GVariantBuilder results_builder;
+  RemoteDesktopDeviceType shared_device_types;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+
+  shared_device_types = remote_desktop_session->shared.device_types;
+  g_variant_builder_add (&results_builder, "{sv}",
+                         "devices", g_variant_new_uint32 (shared_device_types));
+
+  gnome_screen_cast_session = remote_desktop_session->gnome_screen_cast_session;
+  if (gnome_screen_cast_session)
+    {
+      GVariantBuilder streams_builder;
+
+      g_variant_builder_init (&streams_builder, G_VARIANT_TYPE ("a(ua{sv})"));
+      gnome_screen_cast_session_add_stream_properties (gnome_screen_cast_session,
+                                                       &streams_builder);
+      g_variant_builder_add (&results_builder, "{sv}",
+                             "streams",
+                             g_variant_builder_end (&streams_builder));
+    }
+
+  xdp_impl_remote_desktop_complete_start (XDP_IMPL_REMOTE_DESKTOP (impl),
+                                          remote_desktop_session->start_invocation,
+                                          0,
+                                          g_variant_builder_end (&results_builder));
+  remote_desktop_session->start_invocation = NULL;
+}
+
+static void
+on_gnome_screen_cast_session_ready (GnomeScreenCastSession *gnome_screen_cast_session,
+                                    RemoteDesktopSession *remote_desktop_session)
+{
+  start_done (remote_desktop_session);
+}
+
+static gboolean
+open_screen_cast_session (RemoteDesktopSession *remote_desktop_session,
+                          GVariant *source_selections,
+                          GError **error)
+{
+  OrgGnomeMutterRemoteDesktopSession *session_proxy =
+    remote_desktop_session->mutter_session_proxy;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  const char *remote_desktop_session_id;
+
+  remote_desktop_session_id =
+    org_gnome_mutter_remote_desktop_session_get_session_id (session_proxy);
+  gnome_screen_cast_session =
+    gnome_screen_cast_create_session (gnome_screen_cast,
+                                      remote_desktop_session_id,
+                                      error);
+  if (!gnome_screen_cast_session)
+    return FALSE;
+
+  remote_desktop_session->gnome_screen_cast_session = gnome_screen_cast_session;
+  remote_desktop_session->session_ready_handler_id =
+    g_signal_connect (gnome_screen_cast_session, "ready",
+                      G_CALLBACK (on_gnome_screen_cast_session_ready),
+                      remote_desktop_session);
+
+  if (!gnome_screen_cast_session_record_selections (gnome_screen_cast_session,
+                                                    source_selections,
+                                                    error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static gboolean
+start_session (RemoteDesktopSession *remote_desktop_session,
+               GVariant *selections,
+               GError **error)
+{
+  OrgGnomeMutterRemoteDesktopSession *session_proxy;
+  RemoteDesktopDeviceType device_types = 0;
+  g_autoptr(GVariant) source_selections = NULL;
+  gboolean need_streams;
+
+  g_variant_lookup (selections, "selected_device_types", "u", &device_types);
+  remote_desktop_session->shared.device_types = device_types;
+
+  if (g_variant_lookup (selections, "selected_screen_cast_sources", "@a(us)",
+                        &source_selections))
+    {
+      if (!open_screen_cast_session (remote_desktop_session,
+                                     source_selections, error))
+        return FALSE;
+
+      need_streams = TRUE;
+    }
+  else
+    {
+      need_streams = FALSE;
+    }
+
+  session_proxy = remote_desktop_session->mutter_session_proxy;
+  if (!org_gnome_mutter_remote_desktop_session_call_start_sync (session_proxy,
+                                                                NULL,
+                                                                error))
+    return FALSE;
+
+  if (!need_streams)
+    start_done (remote_desktop_session);
+
+  return TRUE;
+}
+
+static void
+cancel_start_session (RemoteDesktopSession *remote_desktop_session,
+                      int response)
+{
+  GVariantBuilder results_builder;
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_remote_desktop_complete_start (XDP_IMPL_REMOTE_DESKTOP (impl),
+                                          remote_desktop_session->start_invocation,
+                                          response,
+                                          g_variant_builder_end (&results_builder));
+}
+
+static gboolean
+handle_start (XdpImplRemoteDesktop *object,
+              GDBusMethodInvocation *invocation,
+              const char *arg_handle,
+              const char *arg_session_handle,
+              const char *arg_app_id,
+              const char *arg_parent_window,
+              GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  RemoteDesktopSession *remote_desktop_session;
+  g_autoptr(GError) error = NULL;
+  RemoteDesktopDialogHandle *dialog_handle;
+  GVariantBuilder results_builder;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+  request = request_new (sender, arg_app_id, arg_handle);
+  request_export (request,
+                  g_dbus_method_invocation_get_connection (invocation));
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  if (!remote_desktop_session)
+    {
+      g_warning ("Attempted to start non existing remote desktop session");
+      goto err;
+    }
+
+  if (remote_desktop_session->dialog_handle)
+    {
+      g_warning ("Screen cast dialog already open");
+      goto err;
+    }
+
+  dialog_handle = create_remote_desktop_dialog (remote_desktop_session,
+                                                invocation,
+                                                request,
+                                                arg_parent_window);
+
+  remote_desktop_session->start_invocation = invocation;
+  remote_desktop_session->dialog_handle = dialog_handle;
+
+  return TRUE;
+
+err:
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE ("a(ua{sv}"));
+  xdp_impl_remote_desktop_complete_start (object, invocation, 2,
+                                          g_variant_builder_end (&results_builder));
+
+  return TRUE;
+}
+
+static gboolean
+handle_notify_pointer_motion (XdpImplRemoteDesktop *object,
+                              GDBusMethodInvocation *invocation,
+                              const char *arg_session_handle,
+                              GVariant *arg_options,
+                              double dx,
+                              double dy)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_pointer_motion_relative (proxy,
+                                                                               dx, dy,
+                                                                               NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_pointer_motion (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_pointer_motion_absolute (XdpImplRemoteDesktop *object,
+                                       GDBusMethodInvocation *invocation,
+                                       const char *arg_session_handle,
+                                       GVariant *arg_options,
+                                       uint32_t stream,
+                                       double x,
+                                       double y)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+  const char *stream_path;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+  gnome_screen_cast_session = remote_desktop_session->gnome_screen_cast_session;
+
+  stream_path = gnome_screen_cast_session_get_stream_path_from_id (gnome_screen_cast_session,
+                                                                   stream);
+  org_gnome_mutter_remote_desktop_session_call_notify_pointer_motion_absolute (proxy,
+                                                                               stream_path,
+                                                                               x, y,
+                                                                               NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_pointer_motion_absolute (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_pointer_button (XdpImplRemoteDesktop *object,
+                              GDBusMethodInvocation *invocation,
+                              const char *arg_session_handle,
+                              GVariant *arg_options,
+                              int32_t button,
+                              uint32_t state)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_pointer_button (proxy,
+                                                                      button, state,
+                                                                      NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_pointer_button (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_pointer_axis (XdpImplRemoteDesktop *object,
+                            GDBusMethodInvocation *invocation,
+                            const char *arg_session_handle,
+                            GVariant *arg_options,
+                            double dx,
+                            double dy)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_pointer_axis (proxy,
+                                                                    dx, dy,
+                                                                    NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_pointer_axis (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_pointer_axis_discrete (XdpImplRemoteDesktop *object,
+                                     GDBusMethodInvocation *invocation,
+                                     const char *arg_session_handle,
+                                     GVariant *arg_options,
+                                     uint32_t axis,
+                                     int32_t steps)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_pointer_axis_discrete (proxy,
+                                                                             axis, steps,
+                                                                             NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_pointer_axis_discrete (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_keyboard_keycode (XdpImplRemoteDesktop *object,
+                                GDBusMethodInvocation *invocation,
+                                const char *arg_session_handle,
+                                GVariant *arg_options,
+                                int32_t keycode,
+                                uint32_t state)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_keyboard_keycode (proxy,
+                                                                        keycode, state,
+                                                                        NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_keyboard_keycode (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_keyboard_keysym (XdpImplRemoteDesktop *object,
+                               GDBusMethodInvocation *invocation,
+                               const char *arg_session_handle,
+                               GVariant *arg_options,
+                               int32_t keysym,
+                               uint32_t state)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_keyboard_keysym (proxy,
+                                                                       keysym, state,
+                                                                       NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_keyboard_keysym (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_touch_down (XdpImplRemoteDesktop *object,
+                          GDBusMethodInvocation *invocation,
+                          const char *arg_session_handle,
+                          GVariant *arg_options,
+                          uint32_t stream,
+                          uint32_t slot,
+                          double x,
+                          double y)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+  const char *stream_path;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+  gnome_screen_cast_session = remote_desktop_session->gnome_screen_cast_session;
+
+  stream_path = gnome_screen_cast_session_get_stream_path_from_id (gnome_screen_cast_session,
+                                                                   stream);
+  org_gnome_mutter_remote_desktop_session_call_notify_touch_down (proxy,
+                                                                  stream_path,
+                                                                  slot,
+                                                                  x, y,
+                                                                  NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_touch_down (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_touch_motion (XdpImplRemoteDesktop *object,
+                            GDBusMethodInvocation *invocation,
+                            const char *arg_session_handle,
+                            GVariant *arg_options,
+                            uint32_t stream,
+                            uint32_t slot,
+                            double x,
+                            double y)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+  const char *stream_path;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+  gnome_screen_cast_session = remote_desktop_session->gnome_screen_cast_session;
+
+  stream_path = gnome_screen_cast_session_get_stream_path_from_id (gnome_screen_cast_session,
+                                                                   stream);
+  org_gnome_mutter_remote_desktop_session_call_notify_touch_motion (proxy,
+                                                                    stream_path,
+                                                                    slot,
+                                                                    x, y,
+                                                                    NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_touch_motion (object, invocation);
+  return TRUE;
+}
+
+static gboolean
+handle_notify_touch_up (XdpImplRemoteDesktop *object,
+                        GDBusMethodInvocation *invocation,
+                        const char *arg_session_handle,
+                        GVariant *arg_options,
+                        uint32_t slot)
+{
+  RemoteDesktopSession *remote_desktop_session;
+  OrgGnomeMutterRemoteDesktopSession *proxy;
+
+  remote_desktop_session =
+    (RemoteDesktopSession *)lookup_session (arg_session_handle);
+  proxy = remote_desktop_session->mutter_session_proxy;
+
+  org_gnome_mutter_remote_desktop_session_call_notify_touch_up (proxy,
+                                                                slot,
+                                                                NULL, NULL, NULL);
+
+  xdp_impl_remote_desktop_complete_notify_touch_up (object, invocation);
+  return TRUE;
+}
+
+static void
+remote_desktop_name_appeared (GDBusConnection *connection,
+                              const char *name,
+                              const char *name_owner,
+                              gpointer user_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  remote_desktop =
+    org_gnome_mutter_remote_desktop_proxy_new_sync (impl_connection,
+                                                    G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                    "org.gnome.Mutter.RemoteDesktop",
+                                                    "/org/gnome/Mutter/RemoteDesktop",
+                                                    NULL,
+                                                    &error);
+  if (!remote_desktop)
+    {
+      g_warning ("Failed to acquire org.gnome.Mutter.RemoteDesktop proxy: %s",
+                 error->message);
+      return;
+    }
+
+  impl = G_DBUS_INTERFACE_SKELETON (xdp_impl_remote_desktop_skeleton_new ());
+
+  g_signal_connect (impl, "handle-create-session",
+                    G_CALLBACK (handle_create_session), NULL);
+  g_signal_connect (impl, "handle-select-devices",
+                    G_CALLBACK (handle_select_devices), NULL);
+  g_signal_connect (impl, "handle-start",
+                    G_CALLBACK (handle_start), NULL);
+
+  g_signal_connect (impl, "handle-notify-pointer-motion",
+                    G_CALLBACK (handle_notify_pointer_motion), NULL);
+  g_signal_connect (impl, "handle-notify-pointer-motion-absolute",
+                    G_CALLBACK (handle_notify_pointer_motion_absolute), NULL);
+  g_signal_connect (impl, "handle-notify-pointer-button",
+                    G_CALLBACK (handle_notify_pointer_button), NULL);
+  g_signal_connect (impl, "handle-notify-pointer-axis",
+                    G_CALLBACK (handle_notify_pointer_axis), NULL);
+  g_signal_connect (impl, "handle-notify-pointer-axis-discrete",
+                    G_CALLBACK (handle_notify_pointer_axis_discrete), NULL);
+  g_signal_connect (impl, "handle-notify-keyboard-keycode",
+                    G_CALLBACK (handle_notify_keyboard_keycode), NULL);
+  g_signal_connect (impl, "handle-notify-keyboard-keysym",
+                    G_CALLBACK (handle_notify_keyboard_keysym), NULL);
+  g_signal_connect (impl, "handle-notify-touch-down",
+                    G_CALLBACK (handle_notify_touch_down), NULL);
+  g_signal_connect (impl, "handle-notify-touch-motion",
+                    G_CALLBACK (handle_notify_touch_motion), NULL);
+  g_signal_connect (impl, "handle-notify-touch-up",
+                    G_CALLBACK (handle_notify_touch_up), NULL);
+
+  g_object_set (G_OBJECT (impl),
+                "available-device-types", REMOTE_DESKTOP_DEVICE_TYPE_ALL,
+                NULL);
+
+  if (!g_dbus_interface_skeleton_export (impl,
+                                         impl_connection,
+                                         DESKTOP_PORTAL_OBJECT_PATH,
+                                         &error))
+    {
+      g_warning ("Failed to export remote desktop portal implementation object: %s",
+                 error->message);
+      return;
+    }
+
+  g_debug ("providing %s", g_dbus_interface_skeleton_get_info (impl)->name);
+}
+
+static void
+remote_desktop_name_vanished (GDBusConnection *connection,
+                              const char *name,
+                              gpointer user_data)
+{
+  if (impl)
+    {
+      g_dbus_interface_skeleton_unexport (impl);
+      g_clear_object (&impl);
+    }
+
+  g_clear_object (&remote_desktop);
+}
+
+gboolean
+remote_desktop_init (GDBusConnection *connection,
+                     GError **error)
+{
+  impl_connection = connection;
+  gnome_screen_cast = gnome_screen_cast_new (connection);
+
+  remote_desktop_name_watch = g_bus_watch_name (G_BUS_TYPE_SESSION,
+                                                "org.gnome.Mutter.RemoteDesktop",
+                                                G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                                remote_desktop_name_appeared,
+                                                remote_desktop_name_vanished,
+                                                NULL,
+                                                NULL);
+
+  return TRUE;
+}
+
+static void
+remote_desktop_session_close (Session *session)
+{
+  RemoteDesktopSession *remote_desktop_session = (RemoteDesktopSession *)session;
+  OrgGnomeMutterRemoteDesktopSession *session_proxy;
+  GnomeScreenCastSession *gnome_screen_cast_session;
+  g_autoptr(GError) error = NULL;
+
+  gnome_screen_cast_session = remote_desktop_session->gnome_screen_cast_session;
+  if (gnome_screen_cast_session)
+    {
+      g_signal_handler_disconnect (gnome_screen_cast_session,
+                                   remote_desktop_session->session_ready_handler_id);
+      g_clear_object (&remote_desktop_session->gnome_screen_cast_session);
+    }
+
+  session_proxy = remote_desktop_session->mutter_session_proxy;
+  g_signal_handler_disconnect (session_proxy,
+                               remote_desktop_session->closed_handler_id);
+
+  if (!org_gnome_mutter_remote_desktop_session_call_stop_sync (session_proxy,
+                                                               NULL,
+                                                               &error))
+    {
+      g_warning ("Failed to stop screen cast session: %s", error->message);
+      return;
+    }
+}
+
+static void
+remote_desktop_session_finalize (GObject *object)
+{
+  RemoteDesktopSession *remote_desktop_session = (RemoteDesktopSession *)object;
+
+  g_free (remote_desktop_session->mutter_session_path);
+
+  G_OBJECT_CLASS (remote_desktop_session_parent_class)->finalize (object);
+}
+
+static void
+remote_desktop_session_init (RemoteDesktopSession *remote_desktop_session)
+{
+}
+
+static void
+remote_desktop_session_class_init (RemoteDesktopSessionClass *klass)
+{
+  GObjectClass *gobject_class;
+  SessionClass *session_class;
+
+  gobject_class = (GObjectClass *)klass;
+  gobject_class->finalize = remote_desktop_session_finalize;
+
+  session_class = (SessionClass *)klass;
+  session_class->close = remote_desktop_session_close;
+}

--- a/src/remotedesktop.c
+++ b/src/remotedesktop.c
@@ -34,6 +34,8 @@
 #include "session.h"
 #include "utils.h"
 
+#define SUPPORTED_MUTTER_REMOTE_DESKTOP_API_VERSION 1
+
 typedef struct _RemoteDesktopDialogHandle RemoteDesktopDialogHandle;
 
 typedef struct _RemoteDesktopSession
@@ -842,6 +844,7 @@ remote_desktop_name_appeared (GDBusConnection *connection,
                               gpointer user_data)
 {
   g_autoptr(GError) error = NULL;
+  int api_version;
 
   remote_desktop =
     org_gnome_mutter_remote_desktop_proxy_new_sync (impl_connection,
@@ -854,6 +857,14 @@ remote_desktop_name_appeared (GDBusConnection *connection,
     {
       g_warning ("Failed to acquire org.gnome.Mutter.RemoteDesktop proxy: %s",
                  error->message);
+      return;
+    }
+
+  api_version = org_gnome_mutter_remote_desktop_get_version (remote_desktop);
+  if (api_version != SUPPORTED_MUTTER_REMOTE_DESKTOP_API_VERSION)
+    {
+      g_warning ("org.gnome.Mutter.RemoteDesktop API version not compatible");
+      g_clear_object (&remote_desktop);
       return;
     }
 

--- a/src/remotedesktop.h
+++ b/src/remotedesktop.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gio/gio.h>
+
+#include "session.h"
+
+typedef struct _RemoteDesktopSession RemoteDesktopSession;
+
+typedef enum _RemoteDesktopDeviceType
+{
+  REMOTE_DESKTOP_DEVICE_TYPE_POINTER = 1 << 0,
+  REMOTE_DESKTOP_DEVICE_TYPE_KEYBOARD = 1 << 1,
+  REMOTE_DESKTOP_DEVICE_TYPE_TOUCHSCREEN = 1 << 2,
+
+  REMOTE_DESKTOP_DEVICE_TYPE_ALL = (REMOTE_DESKTOP_DEVICE_TYPE_POINTER |
+                                    REMOTE_DESKTOP_DEVICE_TYPE_KEYBOARD |
+                                    REMOTE_DESKTOP_DEVICE_TYPE_TOUCHSCREEN)
+} RemoteDesktopDeviceType;
+
+gboolean is_remote_desktop_session (Session *session);
+
+void remote_desktop_session_sources_selected (RemoteDesktopSession *session,
+                                              gboolean multiple);
+
+gboolean remote_desktop_init (GDBusConnection *connection,
+                              GError **error);

--- a/src/remotedesktopdialog.c
+++ b/src/remotedesktopdialog.c
@@ -1,0 +1,370 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gdesktopappinfo.h>
+#include <glib/gi18n.h>
+
+#include "remotedesktop.h"
+#include "remotedesktopdialog.h"
+#include "screencastwidget.h"
+
+struct _RemoteDesktopDialog
+{
+  GtkWindow parent;
+
+  GtkWidget *accept_button;
+  GtkWidget *screen_cast_widget;
+  GtkWidget *device_heading;
+  GtkWidget *device_list;
+
+  RemoteDesktopDeviceType device_types;
+
+  struct {
+    gboolean enable;
+    gboolean multiple;
+  } screen_cast;
+
+  gboolean is_device_types_selected;
+  gboolean is_screen_cast_sources_selected;
+};
+
+struct _RemoteDesktopDialogClass
+{
+  GtkWindowClass *parent_class;
+};
+
+enum
+{
+  DONE,
+
+  N_SIGNAL
+};
+
+static guint signals[N_SIGNAL];
+
+static GQuark quark_device_widget_data;
+
+G_DEFINE_TYPE (RemoteDesktopDialog, remote_desktop_dialog, GTK_TYPE_WINDOW)
+
+static void
+add_device_type_selections (RemoteDesktopDialog *dialog,
+                            GVariantBuilder *selections_builder)
+{
+  GList *selected_rows;
+  GList *l;
+  RemoteDesktopDeviceType selected_device_types = 0;
+
+  selected_rows =
+    gtk_list_box_get_selected_rows (GTK_LIST_BOX (dialog->device_list));
+  for (l = selected_rows; l; l = l->next)
+    {
+      GtkWidget *device_type_widget = gtk_bin_get_child (l->data);
+
+      selected_device_types |=
+        GPOINTER_TO_INT (g_object_get_qdata (G_OBJECT (device_type_widget),
+                                             quark_device_widget_data));
+    }
+  g_list_free (selected_rows);
+
+  g_variant_builder_add (selections_builder, "{sv}",
+                         "selected_device_types",
+                         g_variant_new_uint32 (selected_device_types));
+}
+
+static void
+button_clicked (GtkWidget *button,
+                RemoteDesktopDialog *dialog)
+{
+  int response;
+  GVariant *selections;
+
+  gtk_widget_hide (GTK_WIDGET (dialog));
+
+  if (button == dialog->accept_button)
+    {
+      GVariantBuilder selections_builder;
+      ScreenCastWidget *screen_cast_widget =
+        SCREEN_CAST_WIDGET (dialog->screen_cast_widget);
+
+      response = GTK_RESPONSE_OK;
+
+      g_variant_builder_init (&selections_builder, G_VARIANT_TYPE_VARDICT);
+
+      add_device_type_selections (dialog, &selections_builder);
+      if (dialog->screen_cast.enable)
+        screen_cast_widget_add_selections (screen_cast_widget,
+                                           &selections_builder);
+      selections = g_variant_builder_end (&selections_builder);
+    }
+  else
+    {
+      response = GTK_RESPONSE_CANCEL;
+      selections = NULL;
+    }
+
+  g_signal_emit (dialog, signals[DONE], 0, response, selections);
+}
+
+static void
+update_button_sensitivity (RemoteDesktopDialog *dialog)
+{
+  gboolean can_accept = FALSE;
+
+  if (dialog->is_screen_cast_sources_selected)
+    can_accept = TRUE;
+
+  if (dialog->is_device_types_selected)
+    can_accept = TRUE;
+
+  if (can_accept)
+    gtk_widget_set_sensitive (dialog->accept_button, TRUE);
+  else
+    gtk_widget_set_sensitive (dialog->accept_button, FALSE);
+}
+
+static GtkWidget *
+create_device_type_widget (RemoteDesktopDeviceType device_type,
+                           const char *name)
+{
+  GtkWidget *device_label;
+
+  device_label = gtk_label_new (name);
+  g_object_set_qdata (G_OBJECT (device_label), quark_device_widget_data,
+                      GINT_TO_POINTER (device_type));
+  gtk_widget_set_margin_top (device_label, 12);
+  gtk_widget_set_margin_bottom (device_label, 12);
+  gtk_widget_show (device_label);
+
+  return device_label;
+}
+
+static void
+update_device_list (RemoteDesktopDialog *dialog)
+{
+  GtkListBox *device_list = GTK_LIST_BOX (dialog->device_list);
+  GList *old_device_type_widgets;
+  GList *l;
+  int n_device_types;
+  int i;
+
+  old_device_type_widgets =
+    gtk_container_get_children (GTK_CONTAINER (device_list));
+  for (l = old_device_type_widgets; l; l = l->next)
+    {
+      GtkWidget *device_type_widget = l->data;
+
+      gtk_container_remove (GTK_CONTAINER (device_list), device_type_widget);
+    }
+  g_list_free (old_device_type_widgets);
+
+  n_device_types = __builtin_popcount (REMOTE_DESKTOP_DEVICE_TYPE_ALL);
+  for (i = 0; i < n_device_types; i++)
+    {
+      RemoteDesktopDeviceType device_type = 1 << i;
+      const char *device_type_name;
+      GtkWidget *device_type_widget;
+
+      if (!(dialog->device_types & device_type))
+        continue;
+
+      switch (device_type)
+        {
+        case REMOTE_DESKTOP_DEVICE_TYPE_POINTER:
+          device_type_name = _("Pointer");
+          break;
+        case REMOTE_DESKTOP_DEVICE_TYPE_KEYBOARD:
+          device_type_name = _("Keyboard");
+          break;
+        case REMOTE_DESKTOP_DEVICE_TYPE_TOUCHSCREEN:
+          device_type_name = _("Touch screen");
+          break;
+        case REMOTE_DESKTOP_DEVICE_TYPE_ALL:
+          g_assert_not_reached ();
+        }
+
+      device_type_widget = create_device_type_widget (device_type,
+                                                      device_type_name);
+      gtk_container_add (GTK_CONTAINER (device_list), device_type_widget);
+    }
+}
+
+static gboolean
+is_row_selected (GtkListBoxRow *row)
+{
+  return GPOINTER_TO_INT (g_object_get_data (G_OBJECT (row),
+                                             "is-row-selected"));
+}
+
+static void
+set_row_is_selected (GtkListBoxRow *row,
+                     gboolean is_selected)
+{
+  g_object_set_data (G_OBJECT (row),
+                     "is-row-selected",
+                     GINT_TO_POINTER (is_selected));
+}
+
+static void
+on_row_activated (GtkListBox *box,
+                  GtkListBoxRow *row,
+                  RemoteDesktopDialog *dialog)
+{
+  if (!row)
+    return;
+
+  if (is_row_selected (row))
+    {
+      set_row_is_selected (row, FALSE);
+      gtk_list_box_unselect_row (box, row);
+    }
+  else
+    {
+      set_row_is_selected (row, TRUE);
+      gtk_list_box_select_row (box, row);
+    }
+}
+
+static void
+on_selected_rows_changed (GtkListBox *box,
+                          RemoteDesktopDialog *dialog)
+{
+  GList *selected_rows;
+
+  selected_rows = gtk_list_box_get_selected_rows (box);
+  dialog->is_device_types_selected = !!selected_rows;
+  g_list_free (selected_rows);
+
+  update_button_sensitivity (dialog);
+}
+
+static void
+update_device_list_box_header (GtkListBoxRow *row,
+                               GtkListBoxRow *before,
+                               gpointer user_data)
+{
+  GtkWidget *header;
+
+  if (before)
+    header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+  else
+    header = NULL;
+
+  gtk_list_box_row_set_header (row, header);
+}
+
+static void
+on_has_selection_changed (ScreenCastWidget *screen_cast_widget,
+                          gboolean has_selection,
+                          RemoteDesktopDialog *dialog)
+{
+  dialog->is_screen_cast_sources_selected = has_selection;
+  update_button_sensitivity (dialog);
+}
+
+RemoteDesktopDialog *
+remote_desktop_dialog_new (const char *app_id,
+                           RemoteDesktopDeviceType device_types,
+                           gboolean screen_cast_enable,
+                           gboolean screen_cast_multiple)
+{
+  RemoteDesktopDialog *dialog;
+  g_autofree char *heading = NULL;
+
+  dialog = g_object_new (REMOTE_DESKTOP_TYPE_DIALOG, NULL);
+  dialog->device_types = device_types;
+  dialog->screen_cast.enable = screen_cast_enable;
+  dialog->screen_cast.multiple = screen_cast_multiple;
+
+  if (g_strcmp0 (app_id, "") != 0)
+    {
+      g_autofree char *id = NULL;
+      g_autoptr(GAppInfo) info = NULL;
+
+      id = g_strconcat (app_id, ".desktop", NULL);
+      info = G_APP_INFO (g_desktop_app_info_new (id));
+      heading = g_strdup_printf (_("Select what to share with %s"),
+                                 g_app_info_get_display_name (info));
+    }
+  else
+    {
+      heading = g_strdup (_("Select what to share with the requesting application"));
+    }
+
+  if (screen_cast_enable)
+    {
+      g_signal_connect (dialog->screen_cast_widget, "has-selection-changed",
+                        G_CALLBACK (on_has_selection_changed), dialog);
+      gtk_widget_show (dialog->screen_cast_widget);
+    }
+
+  gtk_label_set_label (GTK_LABEL (dialog->device_heading), heading);
+
+  gtk_list_box_set_selection_mode (GTK_LIST_BOX (dialog->device_list),
+                                   GTK_SELECTION_MULTIPLE);
+  gtk_list_box_set_header_func (GTK_LIST_BOX (dialog->device_list),
+                                update_device_list_box_header,
+                                NULL, NULL);
+
+  g_signal_connect (dialog->device_list, "row-activated",
+                    G_CALLBACK (on_row_activated),
+                    dialog);
+  g_signal_connect (dialog->device_list, "selected-rows-changed",
+                    G_CALLBACK (on_selected_rows_changed),
+                    dialog);
+
+  update_device_list (dialog);
+
+  gtk_widget_show (dialog->device_list);
+
+  return dialog;
+}
+
+static void
+remote_desktop_dialog_init (RemoteDesktopDialog *dialog)
+{
+  gtk_widget_init_template (GTK_WIDGET (dialog));
+}
+
+static void
+remote_desktop_dialog_class_init (RemoteDesktopDialogClass *klass)
+{
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  signals[DONE] = g_signal_new ("done",
+                                G_TYPE_FROM_CLASS (klass),
+                                G_SIGNAL_RUN_LAST,
+                                0,
+                                NULL, NULL,
+                                NULL,
+                                G_TYPE_NONE, 2,
+                                G_TYPE_INT,
+                                G_TYPE_VARIANT);
+
+  init_screen_cast_widget ();
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/remotedesktopdialog.ui");
+  gtk_widget_class_bind_template_child (widget_class, RemoteDesktopDialog, accept_button);
+  gtk_widget_class_bind_template_child (widget_class, RemoteDesktopDialog, screen_cast_widget);
+  gtk_widget_class_bind_template_child (widget_class, RemoteDesktopDialog, device_heading);
+  gtk_widget_class_bind_template_child (widget_class, RemoteDesktopDialog, device_list);
+  gtk_widget_class_bind_template_callback (widget_class, button_clicked);
+
+  quark_device_widget_data = g_quark_from_static_string ("-device-widget-type-quark");
+}

--- a/src/remotedesktopdialog.h
+++ b/src/remotedesktopdialog.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+#define REMOTE_DESKTOP_TYPE_DIALOG (remote_desktop_dialog_get_type ())
+G_DECLARE_FINAL_TYPE (RemoteDesktopDialog, remote_desktop_dialog,
+                      REMOTE_DESKTOP, DIALOG, GtkWindow)
+
+RemoteDesktopDialog * remote_desktop_dialog_new (const char *app_id,
+                                                 RemoteDesktopDeviceType device_types,
+                                                 gboolean screen_cast_enable,
+                                                 gboolean screen_cast_multiple);

--- a/src/remotedesktopdialog.ui
+++ b/src/remotedesktopdialog.ui
@@ -1,0 +1,188 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface  domain="xdg-desktop-portal-gtk">
+  <!-- interface-requires gtk+ 3.22 -->
+  <template class="RemoteDesktopDialog" parent="GtkWindow">
+    <property name="type-hint">dialog</property>
+    <property name="resizable">0</property>
+    <property name="default-width">500</property>
+    <property name="default-height">300</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="titlebar">
+        <property name="visible">1</property>
+        <property name="title" translatable="yes">Remote desktop</property>
+        <child>
+          <object class="GtkButton" id="cancel_button">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">_Cancel</property>
+            <property name="use_underline">1</property>
+            <signal name="clicked" handler="button_clicked"/>
+          </object>
+          <packing>
+            <property name="pack-type">start</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="accept_button">
+            <property name="visible">1</property>
+            <property name="sensitive">0</property>
+            <property name="label" translatable="yes">_Share</property>
+            <property name="use_underline">1</property>
+            <signal name="clicked" handler="button_clicked"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStack" id="main_stack">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="homogeneous">False</property>
+        <property name="transition_type">crossfade</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="shadow-type">none</property>
+                <child>
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="border-width">32</property>
+
+                    <!-- Empty boxes to enforce 1/3 width for the main widgets -->
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                        <property name="height">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
+                        <property name="height">3</property>
+                      </packing>
+                    </child>
+
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="orientation">vertical</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+
+                        <!-- Monitor selection widget -->
+                        <child>
+                          <object class="ScreenCastWidget" id="screen_cast_widget">
+                            <property name="visible">False</property>
+                            <property name="halign">fill</property>
+                            <property name="spacing">6</property>
+                          </object>
+                        </child>
+
+                        <!-- Device selection widget -->
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="halign">fill</property>
+                            <property name="spacing">6</property>
+                            <property name="orientation">vertical</property>
+
+                            <!-- Device selection label -->
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="halign">start</property>
+                                <child>
+                                  <object class="GtkLabel" id="device_heading">
+                                    <property name="visible">True</property>
+                                    <property name="label" translatable="yes"/>
+                                    <property name="xalign">0.0</property>
+                                    <property name="margin_bottom">12</property>
+                                    <attributes>
+                                      <attribute name="weight" value="bold"/>
+                                    </attributes>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+
+                            <!-- List of devices -->
+                            <child>
+                              <object class="GtkFrame">
+                                <property name="visible">True</property>
+                                <property name="valign">start</property>
+                                <property name="halign">fill</property>
+                                <style>
+                                  <class name="view" />
+                                </style>
+                                <child>
+                                  <object class="GtkStack">
+                                    <property name="visible">True</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="vexpand">True</property>
+                                    <property name="transition_type">crossfade</property>
+                                    <child>
+                                      <object class="GtkNotebook" id="notebook_view">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="show_tabs">False</property>
+                                        <property name="show_border">False</property>
+                                        <child>
+                                          <object class="GtkBox" id="box3">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="orientation">vertical</property>
+                                            <child>
+                                              <object class="GtkListBox" id="device_list">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="vexpand">True</property>
+                                              </object>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -390,7 +390,7 @@ start_session (ScreenCastSession *screen_cast_session,
   g_autoptr(GVariant) source_selections = NULL;
 
   gnome_screen_cast_session =
-    gnome_screen_cast_create_session (gnome_screen_cast, error);
+    gnome_screen_cast_create_session (gnome_screen_cast, NULL, error);
   if (!gnome_screen_cast_session)
     return FALSE;
 

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -1,0 +1,785 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <stdint.h>
+
+#include "xdg-desktop-portal-dbus.h"
+#include "shell-dbus.h"
+
+#include "screencast.h"
+#include "screencastdialog.h"
+#include "displaystatetracker.h"
+#include "externalwindow.h"
+#include "request.h"
+#include "session.h"
+#include "utils.h"
+
+typedef struct _ScreenCastDialogHandle ScreenCastDialogHandle;
+
+typedef enum _ScreenCastSourceType
+{
+  SCREEN_CAST_SOURCE_TYPE_ANY,
+  SCREEN_CAST_SOURCE_TYPE_MONITOR,
+  SCREEN_CAST_SOURCE_TYPE_WINDOW,
+} ScreenCastSourceType;
+
+typedef struct _ScreenCastSession
+{
+  Session parent;
+
+  char *parent_window;
+  char *mutter_session_path;
+  OrgGnomeMutterScreenCastSession *mutter_session_proxy;
+  gulong closed_handler_id;
+
+  GList *streams;
+  int n_needed_stream_node_ids;
+
+  struct {
+    gboolean multiple;
+  } select;
+
+  GDBusMethodInvocation *start_invocation;
+  ScreenCastDialogHandle *dialog_handle;
+} ScreenCastSession;
+
+typedef struct _ScreenCastSessionClass
+{
+  SessionClass parent_class;
+} ScreenCastSessionClass;
+
+typedef struct _ScreenCastDialogHandle
+{
+  Request *request;
+  ScreenCastSession *session;
+
+  GtkWidget *dialog;
+  ExternalWindow *external_parent;
+
+  int response;
+} ScreenCastDialogHandle;
+
+typedef struct _ScreenCastStream
+{
+  ScreenCastSession *session;
+  char *stream_path;
+  uint32_t pipewire_node_id;
+  OrgGnomeMutterScreenCastStream *stream_proxy;
+} ScreenCastStream;
+
+static GDBusConnection *impl_connection;
+static guint screen_cast_name_watch;
+static GDBusInterfaceSkeleton *impl;
+static OrgGnomeMutterScreenCast *screen_cast;
+
+GType screen_cast_session_get_type (void);
+G_DEFINE_TYPE (ScreenCastSession, screen_cast_session, session_get_type ())
+
+static void
+start_done (ScreenCastSession *session);
+
+static gboolean
+start_session (ScreenCastSession *session,
+               GVariant *selections,
+               GError **error);
+
+static void
+cancel_start_session (ScreenCastSession *session,
+                      int response);
+
+static void
+screen_cast_dialog_handle_free (ScreenCastDialogHandle *dialog_handle)
+{
+  g_clear_pointer (&dialog_handle->dialog, gtk_widget_destroy);
+  g_clear_object (&dialog_handle->external_parent);
+  g_object_unref (dialog_handle->request);
+
+  g_free (dialog_handle);
+}
+
+static void
+screen_cast_dialog_handle_close (ScreenCastDialogHandle *dialog_handle)
+{
+  screen_cast_dialog_handle_free (dialog_handle);
+}
+
+static gboolean
+handle_close (XdpImplRequest *object,
+              GDBusMethodInvocation *invocation,
+              ScreenCastDialogHandle *dialog_handle)
+{
+  cancel_start_session (dialog_handle->session, 2);
+
+  screen_cast_dialog_handle_close (dialog_handle);
+
+  return FALSE;
+}
+
+static void
+screen_cast_dialog_done (GtkWidget *widget,
+                         int dialog_response,
+                         GVariant *selections,
+                         ScreenCastDialogHandle *dialog_handle)
+{
+  int response;
+
+  switch (dialog_response)
+    {
+    default:
+      g_warning ("Unexpected response: %d", dialog_response);
+      /* Fall through */
+    case GTK_RESPONSE_DELETE_EVENT:
+      response = 2;
+      break;
+
+    case GTK_RESPONSE_CANCEL:
+      response = 1;
+      break;
+
+    case GTK_RESPONSE_OK:
+      response = 0;
+      break;
+    }
+
+  if (response == 0)
+    {
+      g_autoptr(GError) error = NULL;
+
+      if (!start_session (dialog_handle->session, selections, &error))
+        {
+          g_warning ("Failed to start session: %s", error->message);
+          response = 2;
+        }
+    }
+
+  if (response != 0)
+    cancel_start_session (dialog_handle->session, response);
+}
+
+static ScreenCastDialogHandle *
+create_screen_cast_dialog (ScreenCastSession *session,
+                           GDBusMethodInvocation *invocation,
+                           Request *request,
+                           const char *parent_window)
+{
+  ScreenCastDialogHandle *dialog_handle;
+  ExternalWindow *external_parent;
+  GdkScreen *screen;
+  GdkDisplay *display;
+  GtkWidget *fake_parent;
+  GtkWidget *dialog;
+
+  if (parent_window)
+    {
+      external_parent = create_external_window_from_handle (parent_window);
+      if (!external_parent)
+        g_warning ("Failed to associate portal window with parent window %s",
+                   parent_window);
+    }
+  else
+    {
+      external_parent = NULL;
+    }
+
+  if (external_parent)
+    display = external_window_get_display (external_parent);
+  else
+    display = gdk_display_get_default ();
+  screen = gdk_display_get_default_screen (display);
+  fake_parent = g_object_new (GTK_TYPE_WINDOW,
+                              "type", GTK_WINDOW_TOPLEVEL,
+                              "screen", screen,
+                              NULL);
+  g_object_ref_sink (fake_parent);
+
+  dialog = GTK_WIDGET (screen_cast_dialog_new (request->app_id,
+                                               session->select.multiple));
+  gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
+  gtk_window_set_modal (GTK_WINDOW (dialog), TRUE);
+
+  dialog_handle = g_new0 (ScreenCastDialogHandle, 1);
+  dialog_handle->session = session;
+  dialog_handle->request = g_object_ref (request);
+  dialog_handle->external_parent = external_parent;
+  dialog_handle->dialog = dialog;
+
+  g_signal_connect (request, "handle-close",
+                    G_CALLBACK (handle_close), dialog_handle);
+
+  g_signal_connect (dialog, "done",
+                    G_CALLBACK (screen_cast_dialog_done), dialog_handle);
+
+  gtk_widget_realize (dialog);
+
+  if (external_parent)
+    external_window_set_parent_of (external_parent, gtk_widget_get_window (dialog));
+
+  gtk_widget_show (dialog);
+
+  return dialog_handle;
+}
+
+static ScreenCastStream *
+screen_cast_stream_new (ScreenCastSession *screen_cast_session,
+                        const char *stream_path,
+                        OrgGnomeMutterScreenCastStream *stream_proxy)
+{
+  ScreenCastStream *stream;
+
+  stream = g_new0 (ScreenCastStream, 1);
+  stream->session = screen_cast_session;
+  stream->stream_path = g_strdup (stream_path);
+  stream->stream_proxy = stream_proxy;
+
+  return stream;
+}
+
+static void
+screen_cast_stream_free (ScreenCastStream *stream)
+{
+  g_clear_object (&stream->stream_proxy);
+  g_free (stream->stream_path);
+  g_free (stream);
+}
+
+static void
+on_mutter_session_closed (OrgGnomeMutterScreenCastSession *mutter_session_proxy,
+                          ScreenCastSession *screen_cast_session)
+{
+  session_close ((Session *)screen_cast_session);
+}
+
+static ScreenCastSession *
+screen_cast_session_new (const char *app_id,
+                         const char *session_handle,
+                         const char *mutter_session_path,
+                         OrgGnomeMutterScreenCastSession *mutter_session_proxy)
+{
+  ScreenCastSession *screen_cast_session;
+
+  screen_cast_session = g_object_new (screen_cast_session_get_type (),
+                                      "id", session_handle,
+                                      NULL);
+  screen_cast_session->mutter_session_path =
+    g_strdup (mutter_session_path);
+  screen_cast_session->mutter_session_proxy =
+    g_object_ref (mutter_session_proxy);
+
+  screen_cast_session->closed_handler_id =
+    g_signal_connect (screen_cast_session->mutter_session_proxy,
+                      "closed", G_CALLBACK (on_mutter_session_closed),
+                      screen_cast_session);
+
+  return screen_cast_session;
+}
+
+static gboolean
+handle_create_session (XdpImplScreenCast *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char *arg_session_handle,
+                       const char *arg_app_id,
+                       GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  g_autofree char *mutter_session_path = NULL;
+  g_autoptr(GError) error = NULL;
+  int response;
+  GVariantBuilder properties_builder;
+  GVariant *properties;
+  OrgGnomeMutterScreenCastSession *mutter_session_proxy;
+  Session *session;
+  GVariantBuilder results_builder;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  properties = g_variant_builder_end (&properties_builder);
+  if (!org_gnome_mutter_screen_cast_call_create_session_sync (screen_cast,
+                                                              properties,
+                                                              &mutter_session_path,
+                                                              NULL,
+                                                              &error))
+    {
+      g_warning ("Failed to create screen cast session: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  mutter_session_proxy =
+    org_gnome_mutter_screen_cast_session_proxy_new_sync (impl_connection,
+                                                         G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                         "org.gnome.Mutter.ScreenCast",
+                                                         mutter_session_path,
+                                                         NULL,
+                                                         &error);
+  if (!mutter_session_proxy)
+    {
+      g_warning ("Failed to get screen cast session proxy: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  session = (Session *)screen_cast_session_new (arg_app_id,
+                                                arg_session_handle,
+                                                mutter_session_path,
+                                                mutter_session_proxy);
+
+  if (!session_export (session,
+                       g_dbus_method_invocation_get_connection (invocation),
+                       &error))
+    {
+      g_clear_object (&session);
+      g_warning ("Failed to create screen cast session: %s", error->message);
+      response = 2;
+      goto out;
+    }
+
+  response = 0;
+
+out:
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_screen_cast_complete_create_session (object,
+                                                invocation,
+                                                response,
+                                                g_variant_builder_end (&results_builder));
+
+  g_clear_object (&mutter_session_proxy);
+
+  return TRUE;
+}
+
+static void
+on_pipewire_stream_added (OrgGnomeMutterScreenCastStream *stream_proxy,
+                          unsigned int arg_node_id,
+                          ScreenCastStream *stream)
+{
+  stream->pipewire_node_id = arg_node_id;
+  g_return_if_fail (stream->session->n_needed_stream_node_ids > 0);
+  stream->session->n_needed_stream_node_ids--;
+  if (stream->session->n_needed_stream_node_ids == 0)
+    start_done (stream->session);
+}
+
+static gboolean
+handle_select_sources (XdpImplScreenCast *object,
+                       GDBusMethodInvocation *invocation,
+                       const char *arg_handle,
+                       const char *arg_session_handle,
+                       const char *arg_app_id,
+                       GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  ScreenCastSession *screen_cast_session;
+  int response;
+  uint32_t types;
+  gboolean multiple;
+  GVariantBuilder results_builder;
+  GVariant *results;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+  request = request_new (sender, arg_app_id, arg_handle);
+
+  screen_cast_session = (ScreenCastSession *)lookup_session (arg_session_handle);
+  if (!screen_cast_session)
+    {
+      g_warning ("Tried to select sources on non-existing %s", arg_session_handle);
+      response = 2;
+      goto out;
+    }
+
+  if (!g_variant_lookup (arg_options, "multiple", "b", &multiple))
+    multiple = FALSE;
+
+  if (!g_variant_lookup (arg_options, "types", "u", &types))
+    types = SCREEN_CAST_SOURCE_TYPE_MONITOR;
+
+  if (!(types & SCREEN_CAST_SOURCE_TYPE_MONITOR))
+    {
+      g_warning ("Screen cast of a window not implemented");
+      response = 2;
+      goto out;
+    }
+
+  screen_cast_session->select.multiple = multiple;
+  response = 0;
+
+out:
+  request_export (request, g_dbus_method_invocation_get_connection (invocation));
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  results = g_variant_builder_end (&results_builder);
+  xdp_impl_screen_cast_complete_select_sources (object, invocation,
+                                                response, results);
+
+  return TRUE;
+}
+
+static void
+start_done (ScreenCastSession *screen_cast_session)
+{
+  GVariantBuilder streams_builder;
+  GVariantBuilder results_builder;
+  GList *l;
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  g_variant_builder_init (&streams_builder, G_VARIANT_TYPE ("a(ua{sv})"));
+
+  for (l = screen_cast_session->streams; l; l = l->next)
+    {
+      ScreenCastStream *stream = l->data;
+      GVariantBuilder stream_properties_builder;
+      GVariant *parameters;
+      int x, y;
+      int width, height;
+
+      g_variant_builder_init (&stream_properties_builder, G_VARIANT_TYPE_VARDICT);
+
+      parameters =
+        org_gnome_mutter_screen_cast_stream_get_parameters (stream->stream_proxy);
+      if (parameters)
+        {
+          if (g_variant_lookup (parameters, "position", "(ii)", &x, &y))
+            g_variant_builder_add (&stream_properties_builder, "{sv}",
+                                   "position",
+                                   g_variant_new ("(ii)", x, y));
+          if (g_variant_lookup (parameters, "size", "(ii)", &width, &height))
+            g_variant_builder_add (&stream_properties_builder, "{sv}",
+                                   "size",
+                                   g_variant_new ("(ii)", width, height));
+        }
+      else
+        {
+          g_warning ("Screen cast stream %s missing parameters",
+                     stream->stream_path);
+        }
+
+      g_variant_builder_add (&streams_builder, "(ua{sv})",
+                             stream->pipewire_node_id,
+                             &stream_properties_builder);
+    }
+
+  g_variant_builder_add (&results_builder, "{sv}",
+                         "streams",
+                         g_variant_builder_end (&streams_builder));
+
+  xdp_impl_screen_cast_complete_start (XDP_IMPL_SCREEN_CAST (impl),
+                                       screen_cast_session->start_invocation, 0,
+                                       g_variant_builder_end (&results_builder));
+  screen_cast_session->start_invocation = NULL;
+}
+
+static gboolean
+record_monitor (ScreenCastSession *screen_cast_session,
+                const char *connector,
+                GError **error)
+{
+  GVariantBuilder properties_builder;
+  GVariant *properties;
+  OrgGnomeMutterScreenCastSession *session_proxy;
+  g_autofree char *stream_path = NULL;
+  OrgGnomeMutterScreenCastStream *stream_proxy;
+  ScreenCastStream *stream;
+
+  g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  properties = g_variant_builder_end (&properties_builder);
+  session_proxy = screen_cast_session->mutter_session_proxy;
+  if (!org_gnome_mutter_screen_cast_session_call_record_monitor_sync (session_proxy,
+                                                                      connector,
+                                                                      properties,
+                                                                      &stream_path,
+                                                                      NULL,
+                                                                      error))
+    return FALSE;
+
+  stream_proxy =
+    org_gnome_mutter_screen_cast_stream_proxy_new_sync (impl_connection,
+                                                        G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                        "org.gnome.Mutter.ScreenCast",
+                                                        stream_path,
+                                                        NULL,
+                                                        error);
+  if (!stream_proxy)
+    return FALSE;
+
+  stream = screen_cast_stream_new (screen_cast_session,
+                                   stream_path,
+                                   stream_proxy);
+  screen_cast_session->streams = g_list_append (screen_cast_session->streams,
+                                                stream);
+  screen_cast_session->n_needed_stream_node_ids++;
+
+  g_signal_connect (stream_proxy, "pipewire-stream-added",
+                    G_CALLBACK (on_pipewire_stream_added),
+                    stream);
+
+  return TRUE;
+}
+
+static gboolean
+record_streams (ScreenCastSession *screen_cast_session,
+                GVariant *selections,
+                GError **error)
+{
+  GVariantIter selections_iter;
+  GVariant *selection;
+
+  g_variant_iter_init (&selections_iter, selections);
+  while ((selection = g_variant_iter_next_value (&selections_iter)))
+    {
+      ScreenCastSelection selection_type;
+      g_autofree char *key = NULL;
+
+      g_variant_get (selection, "(us)",
+                     &selection_type,
+                     &key);
+
+      switch (selection_type)
+        {
+        case SCREEN_CAST_SELECTION_MONITOR:
+          if (!record_monitor (screen_cast_session, key, error))
+            return FALSE;
+          break;
+        }
+    }
+
+  return TRUE;
+}
+
+static gboolean
+start_session (ScreenCastSession *screen_cast_session,
+               GVariant *selections,
+               GError **error)
+{
+  OrgGnomeMutterScreenCastSession *session_proxy;
+
+  if (!record_streams (screen_cast_session, selections, error))
+    return FALSE;
+
+  session_proxy = screen_cast_session->mutter_session_proxy;
+  if (!org_gnome_mutter_screen_cast_session_call_start_sync (session_proxy,
+                                                             NULL,
+                                                             error))
+    return FALSE;
+
+  return TRUE;
+}
+
+static void
+cancel_start_session (ScreenCastSession *screen_cast_session,
+                      int response)
+{
+  GVariantBuilder results_builder;
+
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE_VARDICT);
+  xdp_impl_screen_cast_complete_start (XDP_IMPL_SCREEN_CAST (impl),
+                                       screen_cast_session->start_invocation,
+                                       response,
+                                       g_variant_builder_end (&results_builder));
+}
+
+static gboolean
+handle_start (XdpImplScreenCast *object,
+              GDBusMethodInvocation *invocation,
+              const char *arg_handle,
+              const char *arg_session_handle,
+              const char *arg_app_id,
+              const char *arg_parent_window,
+              GVariant *arg_options)
+{
+  const char *sender;
+  g_autoptr(Request) request = NULL;
+  ScreenCastSession *screen_cast_session;
+  g_autoptr(GError) error = NULL;
+  ScreenCastDialogHandle *dialog_handle;
+  GVariantBuilder results_builder;
+
+  sender = g_dbus_method_invocation_get_sender (invocation);
+  request = request_new (sender, arg_app_id, arg_handle);
+  request_export (request,
+                  g_dbus_method_invocation_get_connection (invocation));
+
+  screen_cast_session =
+    (ScreenCastSession *)lookup_session (arg_session_handle);
+  if (!screen_cast_session)
+    {
+      g_warning ("Attempted to start non existing screen cast session");
+      goto err;
+    }
+
+  if (screen_cast_session->dialog_handle)
+    {
+      g_warning ("Screen cast dialog already open");
+      goto err;
+    }
+
+  dialog_handle = create_screen_cast_dialog (screen_cast_session,
+                                             invocation,
+                                             request,
+                                             arg_parent_window);
+
+
+  screen_cast_session->start_invocation = invocation;
+  screen_cast_session->dialog_handle = dialog_handle;
+
+  return TRUE;
+
+err:
+  g_variant_builder_init (&results_builder, G_VARIANT_TYPE ("a(ua{sv}"));
+  xdp_impl_screen_cast_complete_start (object, invocation, 2,
+                                       g_variant_builder_end (&results_builder));
+
+  return TRUE;
+}
+
+static void
+screen_cast_name_appeared (GDBusConnection *connection,
+                           const char *name,
+                           const char *name_owner,
+                           gpointer user_data)
+{
+  g_autoptr(GError) error = NULL;
+
+  screen_cast = org_gnome_mutter_screen_cast_proxy_new_sync (impl_connection,
+                                                             G_DBUS_PROXY_FLAGS_DO_NOT_AUTO_START,
+                                                             "org.gnome.Mutter.ScreenCast",
+                                                             "/org/gnome/Mutter/ScreenCast",
+                                                             NULL,
+                                                             &error);
+  if (!screen_cast)
+    {
+      g_warning ("Failed to acquire org.gnome.Mutter.ScreenCast proxy: %s",
+                 error->message);
+      return;
+    }
+
+  impl = G_DBUS_INTERFACE_SKELETON (xdp_impl_screen_cast_skeleton_new ());
+
+  g_signal_connect (impl, "handle-create-session",
+                    G_CALLBACK (handle_create_session), NULL);
+  g_signal_connect (impl, "handle-select-sources",
+                    G_CALLBACK (handle_select_sources), NULL);
+  g_signal_connect (impl, "handle-start",
+                    G_CALLBACK (handle_start), NULL);
+
+  g_object_set (G_OBJECT (impl),
+                "available-source-types", SCREEN_CAST_SOURCE_TYPE_MONITOR,
+                NULL);
+
+  if (!g_dbus_interface_skeleton_export (impl,
+                                         impl_connection,
+                                         DESKTOP_PORTAL_OBJECT_PATH,
+                                         &error))
+    {
+      g_warning ("Failed to export screen cast portal implementation object: %s",
+                 error->message);
+      return;
+    }
+
+  g_debug ("providing %s", g_dbus_interface_skeleton_get_info (impl)->name);
+}
+
+static void
+screen_cast_name_vanished (GDBusConnection *connection,
+                           const char *name,
+                           gpointer user_data)
+{
+  if (impl)
+    {
+      g_dbus_interface_skeleton_unexport (impl);
+      g_clear_object (&impl);
+    }
+
+  g_clear_object (&screen_cast);
+}
+
+gboolean
+screen_cast_init (GDBusConnection *connection,
+                  GError **error)
+{
+  impl_connection = connection;
+  screen_cast_name_watch = g_bus_watch_name (G_BUS_TYPE_SESSION,
+                                             "org.gnome.Mutter.ScreenCast",
+                                             G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                             screen_cast_name_appeared,
+                                             screen_cast_name_vanished,
+                                             NULL,
+                                             NULL);
+
+  return TRUE;
+}
+
+static void
+screen_cast_session_close (Session *session)
+{
+  ScreenCastSession *screen_cast_session = (ScreenCastSession *)session;
+  OrgGnomeMutterScreenCastSession *session_proxy;
+  g_autoptr(GError) error = NULL;
+
+  session_proxy = screen_cast_session->mutter_session_proxy;
+  g_signal_handler_disconnect (session_proxy,
+                               screen_cast_session->closed_handler_id);
+
+  if (!org_gnome_mutter_screen_cast_session_call_stop_sync (session_proxy,
+                                                            NULL,
+                                                            &error))
+    {
+      g_warning ("Failed to stop screen cast session: %s", error->message);
+      return;
+    }
+}
+
+static void
+screen_cast_session_finalize (GObject *object)
+{
+  ScreenCastSession *screen_cast_session = (ScreenCastSession *)object;
+
+  g_list_free_full (screen_cast_session->streams,
+                    (GDestroyNotify) screen_cast_stream_free);
+  g_free (screen_cast_session->mutter_session_path);
+
+  G_OBJECT_CLASS (screen_cast_session_parent_class)->finalize (object);
+}
+
+static void
+screen_cast_session_init (ScreenCastSession *screen_cast_session)
+{
+}
+
+static void
+screen_cast_session_class_init (ScreenCastSessionClass *klass)
+{
+  GObjectClass *gobject_class;
+  SessionClass *session_class;
+
+  gobject_class = (GObjectClass *)klass;
+  gobject_class->finalize = screen_cast_session_finalize;
+
+  session_class = (SessionClass *)klass;
+  session_class->close = screen_cast_session_close;
+}

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -25,6 +25,7 @@
 #include "xdg-desktop-portal-dbus.h"
 
 #include "screencast.h"
+#include "screencastwidget.h"
 #include "screencastdialog.h"
 #include "gnomescreencast.h"
 #include "displaystatetracker.h"
@@ -457,6 +458,7 @@ start_session (ScreenCastSession *screen_cast_session,
                GError **error)
 {
   GnomeScreenCastSession *gnome_screen_cast_session;
+  g_autoptr(GVariant) source_selections = NULL;
 
   gnome_screen_cast_session =
     gnome_screen_cast_create_session (gnome_screen_cast, error);
@@ -474,7 +476,8 @@ start_session (ScreenCastSession *screen_cast_session,
                       G_CALLBACK (on_gnome_screen_cast_session_closed),
                       screen_cast_session);
 
-  if (!record_streams (screen_cast_session, selections, error))
+  g_variant_lookup (selections, "selected_screen_cast_sources", "@a(us)",
+                    &source_selections);
     return FALSE;
 
   if (!gnome_screen_cast_session_start (gnome_screen_cast_session, error))

--- a/src/screencast.h
+++ b/src/screencast.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <glib.h>
+#include <gio/gio.h>
+
+gboolean screen_cast_init (GDBusConnection *connection,
+                           GError **error);

--- a/src/screencastdialog.c
+++ b/src/screencastdialog.c
@@ -22,20 +22,17 @@
 #include <glib/gi18n.h>
 
 #include "screencastdialog.h"
+#include "screencastwidget.h"
 #include "displaystatetracker.h"
 
 struct _ScreenCastDialog
 {
   GtkWindow parent;
 
-  GtkWidget *heading;
   GtkWidget *accept_button;
-  GtkWidget *monitor_list;
+  GtkWidget *screen_cast_widget;
 
   gboolean multiple;
-
-  DisplayStateTracker *display_state_tracker;
-  gulong monitors_changed_handler_id;
 };
 
 struct _ScreenCastDialogClass
@@ -52,32 +49,7 @@ enum
 
 static guint signals[N_SIGNALS];
 
-static GQuark quark_monitor_widget_data;
-
 G_DEFINE_TYPE (ScreenCastDialog, screen_cast_dialog, GTK_TYPE_WINDOW)
-
-static void
-add_selections (ScreenCastDialog *dialog,
-                GVariantBuilder *selections_builder)
-{
-  GList *selected_rows;
-  GList *l;
-
-  selected_rows = gtk_list_box_get_selected_rows (GTK_LIST_BOX (dialog->monitor_list));
-  for (l = selected_rows; l; l = l->next)
-    {
-      GtkWidget *monitor_widget = gtk_bin_get_child (l->data);
-      Monitor *monitor;
-
-      monitor = g_object_get_qdata (G_OBJECT (monitor_widget),
-                                    quark_monitor_widget_data);
-
-      g_variant_builder_add (selections_builder, "(us)",
-                             SCREEN_CAST_SELECTION_MONITOR,
-                             monitor_get_connector (monitor));
-    }
-  g_list_free (selected_rows);
-}
 
 static void
 button_clicked (GtkWidget *button,
@@ -90,12 +62,15 @@ button_clicked (GtkWidget *button,
 
   if (button == dialog->accept_button)
     {
+      ScreenCastWidget *screen_cast_widget =
+        SCREEN_CAST_WIDGET (dialog->screen_cast_widget);
       GVariantBuilder selections_builder;
 
       response = GTK_RESPONSE_OK;
 
-      g_variant_builder_init (&selections_builder, G_VARIANT_TYPE ("a(us)"));
-      add_selections (dialog, &selections_builder);
+      g_variant_builder_init (&selections_builder, G_VARIANT_TYPE ("a{sv}"));
+      screen_cast_widget_add_selections (screen_cast_widget,
+                                         &selections_builder);
       selections = g_variant_builder_end (&selections_builder);
     }
   else
@@ -107,142 +82,15 @@ button_clicked (GtkWidget *button,
   g_signal_emit (dialog, signals[DONE], 0, response, selections);
 }
 
-static GtkWidget *
-create_monitor_widget (LogicalMonitor *logical_monitor)
-{
-  GtkWidget *monitor_widget;
-  GList *l;
-
-  monitor_widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
-  gtk_widget_set_margin_start (monitor_widget, 12);
-  gtk_widget_set_margin_end (monitor_widget, 12);
-
-  for (l = logical_monitor_get_monitors (logical_monitor); l; l = l->next)
-    {
-      Monitor *monitor = l->data;
-      GtkWidget *monitor_label;
-
-      if (!l->prev)
-        g_object_set_qdata (G_OBJECT (monitor_widget),
-                            quark_monitor_widget_data,
-                            monitor);
-
-      monitor_label = gtk_label_new (monitor_get_display_name (monitor));
-      gtk_widget_set_margin_top (monitor_label, 12);
-      gtk_widget_set_margin_bottom (monitor_label, 12);
-      gtk_widget_show (monitor_label);
-      gtk_container_add (GTK_CONTAINER (monitor_widget), monitor_label);
-    }
-
-  gtk_widget_show (monitor_widget);
-  return monitor_widget;
-}
-
 static void
-update_monitors_list (ScreenCastDialog *dialog)
-{
-  GtkListBox *monitor_list = GTK_LIST_BOX (dialog->monitor_list);
-  GList *old_monitor_widgets;
-  GList *logical_monitors;
-  GList *l;
-
-  old_monitor_widgets = gtk_container_get_children (GTK_CONTAINER (monitor_list));
-  for (l = old_monitor_widgets; l; l = l->next)
-    {
-      GtkWidget *monitor_widget = l->data;
-
-      gtk_container_remove (GTK_CONTAINER (monitor_list), monitor_widget);
-    }
-  g_list_free (old_monitor_widgets);
-
-  logical_monitors =
-    display_state_tracker_get_logical_monitors (dialog->display_state_tracker);
-  for (l = logical_monitors; l; l = l->next)
-    {
-      LogicalMonitor *logical_monitor = l->data;
-      GtkWidget *monitor_widget;
-
-      monitor_widget = create_monitor_widget (logical_monitor);
-      gtk_container_add (GTK_CONTAINER (monitor_list), monitor_widget);
-    }
-
-  gtk_widget_show (dialog->monitor_list);
-}
-
-static gboolean
-is_row_selected (GtkListBoxRow *row)
-{
-  return GPOINTER_TO_INT (g_object_get_data (G_OBJECT (row),
-                                             "is-row-selected"));
-}
-
-static void
-set_row_is_selected (GtkListBoxRow *row,
-                     gboolean is_selected)
-{
-  g_object_set_data (G_OBJECT (row),
-                     "is-row-selected",
-                     GINT_TO_POINTER (is_selected));
-}
-
-static void
-on_row_activated (GtkListBox *box,
-                  GtkListBoxRow *row,
-                  ScreenCastDialog *dialog)
-{
-  GList *selected_rows;
-
-  if (!row)
-    return;
-
-  if (dialog->multiple)
-    {
-      if (is_row_selected (row))
-        {
-          set_row_is_selected (row, FALSE);
-          gtk_list_box_unselect_row (box, row);
-        }
-      else
-        {
-          set_row_is_selected (row, TRUE);
-          gtk_list_box_select_row (box, row);
-        }
-    }
-
-  selected_rows = gtk_list_box_get_selected_rows (box);
-
-  g_list_free (selected_rows);
-}
-
-static void
-on_selected_rows_changed (GtkListBox *box,
+on_has_selection_changed (ScreenCastWidget *screen_cast_widget,
+                          gboolean has_selection,
                           ScreenCastDialog *dialog)
 {
-  GList *selected_rows;
-
-  selected_rows = gtk_list_box_get_selected_rows (box);
-
-  if (selected_rows)
+  if (has_selection)
     gtk_widget_set_sensitive (dialog->accept_button, TRUE);
   else
     gtk_widget_set_sensitive (dialog->accept_button, FALSE);
-
-  g_list_free (selected_rows);
-}
-
-static void
-update_monitor_list_box_header (GtkListBoxRow *row,
-                                GtkListBoxRow *before,
-                                gpointer user_data)
-{
-  GtkWidget *header;
-
-  if (before)
-    header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
-  else
-    header = NULL;
-
-  gtk_list_box_row_set_header (row, header);
 }
 
 ScreenCastDialog *
@@ -250,63 +98,14 @@ screen_cast_dialog_new (const char *app_id,
                         gboolean multiple)
 {
   ScreenCastDialog *dialog;
-  g_autofree char *heading = NULL;
+  ScreenCastWidget *screen_cast_widget;
 
   dialog = g_object_new (SCREEN_CAST_TYPE_DIALOG, NULL);
-  dialog->multiple = multiple;
-
-  if (g_strcmp0 (app_id, "") != 0)
-    {
-      g_autofree char *id = NULL;
-      g_autoptr(GAppInfo) info = NULL;
-
-      id = g_strconcat (app_id, ".desktop", NULL);
-      info = G_APP_INFO (g_desktop_app_info_new (id));
-      heading = g_strdup_printf (_("Select monitor to share with %s"),
-                                 g_app_info_get_display_name (info));
-    }
-  else
-    {
-      heading = g_strdup (_("Select monitor to share with the requesting application"));
-    }
-
-  gtk_label_set_label (GTK_LABEL (dialog->heading), heading);
-
-  gtk_list_box_set_selection_mode (GTK_LIST_BOX (dialog->monitor_list),
-                                   multiple ? GTK_SELECTION_MULTIPLE
-                                            : GTK_SELECTION_SINGLE);
-  gtk_list_box_set_header_func (GTK_LIST_BOX (dialog->monitor_list),
-                                update_monitor_list_box_header,
-                                NULL, NULL);
-
-  g_signal_connect (dialog->monitor_list, "row-activated",
-                    G_CALLBACK (on_row_activated),
-                    dialog);
-  g_signal_connect (dialog->monitor_list, "selected-rows-changed",
-                    G_CALLBACK (on_selected_rows_changed),
-                    dialog);
-
-  update_monitors_list (dialog);
+  screen_cast_widget = SCREEN_CAST_WIDGET (dialog->screen_cast_widget);
+  screen_cast_widget_set_app_id (screen_cast_widget, app_id);
+  screen_cast_widget_set_allow_multiple (screen_cast_widget, multiple);
 
   return dialog;
-}
-
-static void
-on_monitors_changed (DisplayStateTracker *display_state_tracker,
-                     ScreenCastDialog *dialog)
-{
-  update_monitors_list (dialog);
-}
-
-static void
-screen_cast_dialog_finalize (GObject *object)
-{
-  ScreenCastDialog *dialog = SCREEN_CAST_DIALOG (object);
-
-  g_signal_handler_disconnect (dialog->display_state_tracker,
-                               dialog->monitors_changed_handler_id);
-
-  G_OBJECT_CLASS (screen_cast_dialog_parent_class)->finalize (object);
 }
 
 static void
@@ -314,21 +113,15 @@ screen_cast_dialog_init (ScreenCastDialog *dialog)
 {
   gtk_widget_init_template (GTK_WIDGET (dialog));
 
-  dialog->display_state_tracker = display_state_tracker_get ();
-  dialog->monitors_changed_handler_id =
-  g_signal_connect (dialog->display_state_tracker,
-                    "monitors-changed",
-                    G_CALLBACK (on_monitors_changed),
-                    dialog);
+  g_signal_connect (dialog->screen_cast_widget, "has-selection-changed",
+                    G_CALLBACK (on_has_selection_changed), dialog);
+  gtk_widget_show (dialog->screen_cast_widget);
 }
 
 static void
 screen_cast_dialog_class_init (ScreenCastDialogClass *klass)
 {
-  GObjectClass *object_class = G_OBJECT_CLASS (klass);
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
-
-  object_class->finalize = screen_cast_dialog_finalize;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (klass),
@@ -340,11 +133,10 @@ screen_cast_dialog_class_init (ScreenCastDialogClass *klass)
                                 G_TYPE_INT,
                                 G_TYPE_VARIANT);
 
+  init_screen_cast_widget ();
+
   gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/screencastdialog.ui");
   gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, accept_button);
-  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, heading);
-  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, monitor_list);
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, screen_cast_widget);
   gtk_widget_class_bind_template_callback (widget_class, button_clicked);
-
-  quark_monitor_widget_data = g_quark_from_static_string ("-monitor-widget-connector-quark");
 }

--- a/src/screencastdialog.c
+++ b/src/screencastdialog.c
@@ -1,0 +1,350 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gdesktopappinfo.h>
+#include <glib/gi18n.h>
+
+#include "screencastdialog.h"
+#include "displaystatetracker.h"
+
+struct _ScreenCastDialog
+{
+  GtkWindow parent;
+
+  GtkWidget *heading;
+  GtkWidget *accept_button;
+  GtkWidget *monitor_list;
+
+  gboolean multiple;
+
+  DisplayStateTracker *display_state_tracker;
+  gulong monitors_changed_handler_id;
+};
+
+struct _ScreenCastDialogClass
+{
+  GtkWindowClass *parent_class;
+};
+
+enum
+{
+  DONE,
+
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS];
+
+static GQuark quark_monitor_widget_data;
+
+G_DEFINE_TYPE (ScreenCastDialog, screen_cast_dialog, GTK_TYPE_WINDOW)
+
+static void
+add_selections (ScreenCastDialog *dialog,
+                GVariantBuilder *selections_builder)
+{
+  GList *selected_rows;
+  GList *l;
+
+  selected_rows = gtk_list_box_get_selected_rows (GTK_LIST_BOX (dialog->monitor_list));
+  for (l = selected_rows; l; l = l->next)
+    {
+      GtkWidget *monitor_widget = gtk_bin_get_child (l->data);
+      Monitor *monitor;
+
+      monitor = g_object_get_qdata (G_OBJECT (monitor_widget),
+                                    quark_monitor_widget_data);
+
+      g_variant_builder_add (selections_builder, "(us)",
+                             SCREEN_CAST_SELECTION_MONITOR,
+                             monitor_get_connector (monitor));
+    }
+  g_list_free (selected_rows);
+}
+
+static void
+button_clicked (GtkWidget *button,
+                ScreenCastDialog *dialog)
+{
+  int response;
+  GVariant *selections;
+
+  gtk_widget_hide (GTK_WIDGET (dialog));
+
+  if (button == dialog->accept_button)
+    {
+      GVariantBuilder selections_builder;
+
+      response = GTK_RESPONSE_OK;
+
+      g_variant_builder_init (&selections_builder, G_VARIANT_TYPE ("a(us)"));
+      add_selections (dialog, &selections_builder);
+      selections = g_variant_builder_end (&selections_builder);
+    }
+  else
+    {
+      response = GTK_RESPONSE_CANCEL;
+      selections = NULL;
+    }
+
+  g_signal_emit (dialog, signals[DONE], 0, response, selections);
+}
+
+static GtkWidget *
+create_monitor_widget (LogicalMonitor *logical_monitor)
+{
+  GtkWidget *monitor_widget;
+  GList *l;
+
+  monitor_widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
+  gtk_widget_set_margin_start (monitor_widget, 12);
+  gtk_widget_set_margin_end (monitor_widget, 12);
+
+  for (l = logical_monitor_get_monitors (logical_monitor); l; l = l->next)
+    {
+      Monitor *monitor = l->data;
+      GtkWidget *monitor_label;
+
+      if (!l->prev)
+        g_object_set_qdata (G_OBJECT (monitor_widget),
+                            quark_monitor_widget_data,
+                            monitor);
+
+      monitor_label = gtk_label_new (monitor_get_display_name (monitor));
+      gtk_widget_set_margin_top (monitor_label, 12);
+      gtk_widget_set_margin_bottom (monitor_label, 12);
+      gtk_widget_show (monitor_label);
+      gtk_container_add (GTK_CONTAINER (monitor_widget), monitor_label);
+    }
+
+  gtk_widget_show (monitor_widget);
+  return monitor_widget;
+}
+
+static void
+update_monitors_list (ScreenCastDialog *dialog)
+{
+  GtkListBox *monitor_list = GTK_LIST_BOX (dialog->monitor_list);
+  GList *old_monitor_widgets;
+  GList *logical_monitors;
+  GList *l;
+
+  old_monitor_widgets = gtk_container_get_children (GTK_CONTAINER (monitor_list));
+  for (l = old_monitor_widgets; l; l = l->next)
+    {
+      GtkWidget *monitor_widget = l->data;
+
+      gtk_container_remove (GTK_CONTAINER (monitor_list), monitor_widget);
+    }
+  g_list_free (old_monitor_widgets);
+
+  logical_monitors =
+    display_state_tracker_get_logical_monitors (dialog->display_state_tracker);
+  for (l = logical_monitors; l; l = l->next)
+    {
+      LogicalMonitor *logical_monitor = l->data;
+      GtkWidget *monitor_widget;
+
+      monitor_widget = create_monitor_widget (logical_monitor);
+      gtk_container_add (GTK_CONTAINER (monitor_list), monitor_widget);
+    }
+
+  gtk_widget_show (dialog->monitor_list);
+}
+
+static gboolean
+is_row_selected (GtkListBoxRow *row)
+{
+  return GPOINTER_TO_INT (g_object_get_data (G_OBJECT (row),
+                                             "is-row-selected"));
+}
+
+static void
+set_row_is_selected (GtkListBoxRow *row,
+                     gboolean is_selected)
+{
+  g_object_set_data (G_OBJECT (row),
+                     "is-row-selected",
+                     GINT_TO_POINTER (is_selected));
+}
+
+static void
+on_row_activated (GtkListBox *box,
+                  GtkListBoxRow *row,
+                  ScreenCastDialog *dialog)
+{
+  GList *selected_rows;
+
+  if (!row)
+    return;
+
+  if (dialog->multiple)
+    {
+      if (is_row_selected (row))
+        {
+          set_row_is_selected (row, FALSE);
+          gtk_list_box_unselect_row (box, row);
+        }
+      else
+        {
+          set_row_is_selected (row, TRUE);
+          gtk_list_box_select_row (box, row);
+        }
+    }
+
+  selected_rows = gtk_list_box_get_selected_rows (box);
+
+  g_list_free (selected_rows);
+}
+
+static void
+on_selected_rows_changed (GtkListBox *box,
+                          ScreenCastDialog *dialog)
+{
+  GList *selected_rows;
+
+  selected_rows = gtk_list_box_get_selected_rows (box);
+
+  if (selected_rows)
+    gtk_widget_set_sensitive (dialog->accept_button, TRUE);
+  else
+    gtk_widget_set_sensitive (dialog->accept_button, FALSE);
+
+  g_list_free (selected_rows);
+}
+
+static void
+update_monitor_list_box_header (GtkListBoxRow *row,
+                                GtkListBoxRow *before,
+                                gpointer user_data)
+{
+  GtkWidget *header;
+
+  if (before)
+    header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+  else
+    header = NULL;
+
+  gtk_list_box_row_set_header (row, header);
+}
+
+ScreenCastDialog *
+screen_cast_dialog_new (const char *app_id,
+                        gboolean multiple)
+{
+  ScreenCastDialog *dialog;
+  g_autofree char *heading = NULL;
+
+  dialog = g_object_new (SCREEN_CAST_TYPE_DIALOG, NULL);
+  dialog->multiple = multiple;
+
+  if (g_strcmp0 (app_id, "") != 0)
+    {
+      g_autofree char *id = NULL;
+      g_autoptr(GAppInfo) info = NULL;
+
+      id = g_strconcat (app_id, ".desktop", NULL);
+      info = G_APP_INFO (g_desktop_app_info_new (id));
+      heading = g_strdup_printf (_("Select monitor to share with %s"),
+                                 g_app_info_get_display_name (info));
+    }
+  else
+    {
+      heading = g_strdup (_("Select monitor to share with the requesting application"));
+    }
+
+  gtk_label_set_label (GTK_LABEL (dialog->heading), heading);
+
+  gtk_list_box_set_selection_mode (GTK_LIST_BOX (dialog->monitor_list),
+                                   multiple ? GTK_SELECTION_MULTIPLE
+                                            : GTK_SELECTION_SINGLE);
+  gtk_list_box_set_header_func (GTK_LIST_BOX (dialog->monitor_list),
+                                update_monitor_list_box_header,
+                                NULL, NULL);
+
+  g_signal_connect (dialog->monitor_list, "row-activated",
+                    G_CALLBACK (on_row_activated),
+                    dialog);
+  g_signal_connect (dialog->monitor_list, "selected-rows-changed",
+                    G_CALLBACK (on_selected_rows_changed),
+                    dialog);
+
+  update_monitors_list (dialog);
+
+  return dialog;
+}
+
+static void
+on_monitors_changed (DisplayStateTracker *display_state_tracker,
+                     ScreenCastDialog *dialog)
+{
+  update_monitors_list (dialog);
+}
+
+static void
+screen_cast_dialog_finalize (GObject *object)
+{
+  ScreenCastDialog *dialog = SCREEN_CAST_DIALOG (object);
+
+  g_signal_handler_disconnect (dialog->display_state_tracker,
+                               dialog->monitors_changed_handler_id);
+
+  G_OBJECT_CLASS (screen_cast_dialog_parent_class)->finalize (object);
+}
+
+static void
+screen_cast_dialog_init (ScreenCastDialog *dialog)
+{
+  gtk_widget_init_template (GTK_WIDGET (dialog));
+
+  dialog->display_state_tracker = display_state_tracker_get ();
+  dialog->monitors_changed_handler_id =
+  g_signal_connect (dialog->display_state_tracker,
+                    "monitors-changed",
+                    G_CALLBACK (on_monitors_changed),
+                    dialog);
+}
+
+static void
+screen_cast_dialog_class_init (ScreenCastDialogClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->finalize = screen_cast_dialog_finalize;
+
+  signals[DONE] = g_signal_new ("done",
+                                G_TYPE_FROM_CLASS (klass),
+                                G_SIGNAL_RUN_LAST,
+                                0,
+                                NULL, NULL,
+                                NULL,
+                                G_TYPE_NONE, 2,
+                                G_TYPE_INT,
+                                G_TYPE_VARIANT);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/screencastdialog.ui");
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, accept_button);
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, heading);
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastDialog, monitor_list);
+  gtk_widget_class_bind_template_callback (widget_class, button_clicked);
+
+  quark_monitor_widget_data = g_quark_from_static_string ("-monitor-widget-connector-quark");
+}

--- a/src/screencastdialog.h
+++ b/src/screencastdialog.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+typedef enum _ScreenCastSelection
+{
+  SCREEN_CAST_SELECTION_MONITOR
+} ScreenCastSelection;
+
+#define SCREEN_CAST_TYPE_DIALOG (screen_cast_dialog_get_type ())
+G_DECLARE_FINAL_TYPE (ScreenCastDialog, screen_cast_dialog,
+                      SCREEN_CAST, DIALOG, GtkWindow)
+
+ScreenCastDialog * screen_cast_dialog_new (const char *app_id,
+                                           gboolean multiple);

--- a/src/screencastdialog.h
+++ b/src/screencastdialog.h
@@ -20,11 +20,6 @@
 
 #include <gtk/gtk.h>
 
-typedef enum _ScreenCastSelection
-{
-  SCREEN_CAST_SELECTION_MONITOR
-} ScreenCastSelection;
-
 #define SCREEN_CAST_TYPE_DIALOG (screen_cast_dialog_get_type ())
 G_DECLARE_FINAL_TYPE (ScreenCastDialog, screen_cast_dialog,
                       SCREEN_CAST, DIALOG, GtkWindow)

--- a/src/screencastdialog.ui
+++ b/src/screencastdialog.ui
@@ -82,74 +82,17 @@
                       </packing>
                     </child>
 
-                    <!-- Monitor selection label -->
+                    <!-- Monitor selection widget -->
                     <child>
-                      <object class="GtkBox">
+                      <object class="ScreenCastWidget" id="screen_cast_widget">
                         <property name="visible">True</property>
                         <property name="hexpand">True</property>
-                        <property name="halign">start</property>
+                        <property name="halign">fill</property>
                         <property name="spacing">6</property>
-                        <child>
-                          <object class="GtkLabel" id="heading">
-                            <property name="visible">True</property>
-                            <property name="label" translatable="yes"/>
-                            <property name="xalign">0.0</property>
-                            <property name="margin_bottom">12</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                        </child>
                       </object>
                       <packing>
                         <property name="left-attach">1</property>
                         <property name="top-attach">1</property>
-                      </packing>
-                    </child>
-
-                    <!-- List of monitors -->
-                    <child>
-                      <object class="GtkFrame">
-                        <property name="visible">True</property>
-                        <property name="valign">start</property>
-                        <style>
-                          <class name="view" />
-                        </style>
-                        <child>
-                          <object class="GtkStack">
-                            <property name="visible">True</property>
-                            <property name="hexpand">True</property>
-                            <property name="vexpand">True</property>
-                            <property name="transition_type">crossfade</property>
-                            <child>
-                              <object class="GtkNotebook" id="notebook_view">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="show_tabs">False</property>
-                                <property name="show_border">False</property>
-                                <child>
-                                  <object class="GtkBox" id="box3">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="orientation">vertical</property>
-                                    <child>
-                                      <object class="GtkListBox" id="monitor_list">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="hexpand">True</property>
-                                        <property name="vexpand">True</property>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                      <packing>
-                        <property name="left-attach">1</property>
-                        <property name="top-attach">2</property>
                       </packing>
                     </child>
                   </object>

--- a/src/screencastdialog.ui
+++ b/src/screencastdialog.ui
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="xdg-desktop-portal-gtk">
+  <!-- interface-requires gtk+ 3.22 -->
+  <template class="ScreenCastDialog" parent="GtkWindow">
+    <property name="type-hint">dialog</property>
+    <property name="resizable">0</property>
+    <property name="default-width">500</property>
+    <property name="default-height">300</property>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="titlebar">
+        <property name="visible">1</property>
+        <property name="title" translatable="yes">Screen casting</property>
+        <child>
+          <object class="GtkButton" id="cancel_button">
+            <property name="visible">1</property>
+            <property name="label" translatable="yes">_Cancel</property>
+            <property name="use_underline">1</property>
+            <signal name="clicked" handler="button_clicked"/>
+          </object>
+          <packing>
+            <property name="pack-type">start</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="accept_button">
+            <property name="visible">1</property>
+            <property name="sensitive">0</property>
+            <property name="label" translatable="yes">_Share</property>
+            <property name="use_underline">1</property>
+            <signal name="clicked" handler="button_clicked"/>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack-type">end</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStack" id="main_stack">
+        <property name="visible">True</property>
+        <property name="can-focus">True</property>
+        <property name="homogeneous">False</property>
+        <property name="transition_type">crossfade</property>
+        <child>
+          <object class="GtkScrolledWindow">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="hscrollbar-policy">never</property>
+            <child>
+              <object class="GtkViewport">
+                <property name="visible">True</property>
+                <property name="shadow-type">none</property>
+                <child>
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="border-width">32</property>
+
+                    <!-- Empty boxes to enforce 1/3 width for the main widgets -->
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                        <property name="height">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">2</property>
+                        <property name="top-attach">0</property>
+                        <property name="height">3</property>
+                      </packing>
+                    </child>
+
+                    <!-- Monitor selection label -->
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="halign">start</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel" id="heading">
+                            <property name="visible">True</property>
+                            <property name="label" translatable="yes"/>
+                            <property name="xalign">0.0</property>
+                            <property name="margin_bottom">12</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+
+                    <!-- List of monitors -->
+                    <child>
+                      <object class="GtkFrame">
+                        <property name="visible">True</property>
+                        <property name="valign">start</property>
+                        <style>
+                          <class name="view" />
+                        </style>
+                        <child>
+                          <object class="GtkStack">
+                            <property name="visible">True</property>
+                            <property name="hexpand">True</property>
+                            <property name="vexpand">True</property>
+                            <property name="transition_type">crossfade</property>
+                            <child>
+                              <object class="GtkNotebook" id="notebook_view">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="show_tabs">False</property>
+                                <property name="show_border">False</property>
+                                <child>
+                                  <object class="GtkBox" id="box3">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="orientation">vertical</property>
+                                    <child>
+                                      <object class="GtkListBox" id="monitor_list">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="vexpand">True</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -41,8 +41,6 @@ struct _ScreenCastWidget
   GtkWidget *monitor_heading;
   GtkWidget *monitor_list;
 
-  gboolean multiple;
-
   DisplayStateTracker *display_state_tracker;
   gulong monitors_changed_handler_id;
 };
@@ -132,28 +130,19 @@ on_row_activated (GtkListBox *box,
                   GtkListBoxRow *row,
                   ScreenCastWidget *widget)
 {
-  GList *selected_rows;
-
   if (!row)
     return;
 
-  if (widget->multiple)
+  if (is_row_selected (row))
     {
-      if (is_row_selected (row))
-        {
-          set_row_is_selected (row, FALSE);
-          gtk_list_box_unselect_row (box, row);
-        }
-      else
-        {
-          set_row_is_selected (row, TRUE);
-          gtk_list_box_select_row (box, row);
-        }
+      set_row_is_selected (row, FALSE);
+      gtk_list_box_unselect_row (box, row);
     }
-
-  selected_rows = gtk_list_box_get_selected_rows (box);
-
-  g_list_free (selected_rows);
+  else
+    {
+      set_row_is_selected (row, TRUE);
+      gtk_list_box_select_row (box, row);
+    }
 }
 
 static void
@@ -266,8 +255,6 @@ void
 screen_cast_widget_set_allow_multiple (ScreenCastWidget *widget,
                                        gboolean multiple)
 {
-  widget->multiple = multiple;
-
   gtk_list_box_set_selection_mode (GTK_LIST_BOX (widget->monitor_list),
                                    multiple ? GTK_SELECTION_MULTIPLE
                                             : GTK_SELECTION_SINGLE);

--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -1,0 +1,345 @@
+/*
+ * Copyright © 2017-2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <gio/gdesktopappinfo.h>
+#include <glib/gi18n.h>
+#include <gtk/gtk.h>
+
+#include "screencastwidget.h"
+#include "displaystatetracker.h"
+
+enum
+{
+  HAS_SELECTION_CHANGED,
+
+  N_SIGNALS
+};
+
+static guint signals[N_SIGNALS];
+
+struct _ScreenCastWidget
+{
+  GtkBox parent;
+
+  GtkWidget *monitor_heading;
+  GtkWidget *monitor_list;
+
+  gboolean multiple;
+
+  DisplayStateTracker *display_state_tracker;
+  gulong monitors_changed_handler_id;
+};
+
+static GQuark quark_monitor_widget_data;
+
+G_DEFINE_TYPE (ScreenCastWidget, screen_cast_widget, GTK_TYPE_BOX)
+
+static GtkWidget *
+create_monitor_widget (LogicalMonitor *logical_monitor)
+{
+  GtkWidget *monitor_widget;
+  GList *l;
+
+  monitor_widget = gtk_box_new (GTK_ORIENTATION_VERTICAL, 12);
+  gtk_widget_set_margin_start (monitor_widget, 12);
+  gtk_widget_set_margin_end (monitor_widget, 12);
+
+  for (l = logical_monitor_get_monitors (logical_monitor); l; l = l->next)
+    {
+      Monitor *monitor = l->data;
+      GtkWidget *monitor_label;
+
+      if (!l->prev)
+        g_object_set_qdata (G_OBJECT (monitor_widget),
+                            quark_monitor_widget_data,
+                            monitor);
+
+      monitor_label = gtk_label_new (monitor_get_display_name (monitor));
+      gtk_widget_set_margin_top (monitor_label, 12);
+      gtk_widget_set_margin_bottom (monitor_label, 12);
+      gtk_widget_show (monitor_label);
+      gtk_container_add (GTK_CONTAINER (monitor_widget), monitor_label);
+    }
+
+  gtk_widget_show (monitor_widget);
+  return monitor_widget;
+}
+
+static void
+update_monitors_list (ScreenCastWidget *widget)
+{
+  GtkListBox *monitor_list = GTK_LIST_BOX (widget->monitor_list);
+  GList *old_monitor_widgets;
+  GList *logical_monitors;
+  GList *l;
+
+  old_monitor_widgets = gtk_container_get_children (GTK_CONTAINER (monitor_list));
+  for (l = old_monitor_widgets; l; l = l->next)
+    {
+      GtkWidget *monitor_widget = l->data;
+
+      gtk_container_remove (GTK_CONTAINER (monitor_list), monitor_widget);
+    }
+  g_list_free (old_monitor_widgets);
+
+  logical_monitors =
+    display_state_tracker_get_logical_monitors (widget->display_state_tracker);
+  for (l = logical_monitors; l; l = l->next)
+    {
+      LogicalMonitor *logical_monitor = l->data;
+      GtkWidget *monitor_widget;
+
+      monitor_widget = create_monitor_widget (logical_monitor);
+      gtk_container_add (GTK_CONTAINER (monitor_list), monitor_widget);
+    }
+}
+
+static gboolean
+is_row_selected (GtkListBoxRow *row)
+{
+  return GPOINTER_TO_INT (g_object_get_data (G_OBJECT (row),
+                                             "is-row-selected"));
+}
+
+static void
+set_row_is_selected (GtkListBoxRow *row,
+                     gboolean is_selected)
+{
+  g_object_set_data (G_OBJECT (row),
+                     "is-row-selected",
+                     GINT_TO_POINTER (is_selected));
+}
+
+static void
+on_row_activated (GtkListBox *box,
+                  GtkListBoxRow *row,
+                  ScreenCastWidget *widget)
+{
+  GList *selected_rows;
+
+  if (!row)
+    return;
+
+  if (widget->multiple)
+    {
+      if (is_row_selected (row))
+        {
+          set_row_is_selected (row, FALSE);
+          gtk_list_box_unselect_row (box, row);
+        }
+      else
+        {
+          set_row_is_selected (row, TRUE);
+          gtk_list_box_select_row (box, row);
+        }
+    }
+
+  selected_rows = gtk_list_box_get_selected_rows (box);
+
+  g_list_free (selected_rows);
+}
+
+static void
+on_selected_rows_changed (GtkListBox *box,
+                          ScreenCastWidget *widget)
+{
+  GList *selected_rows;
+
+  selected_rows = gtk_list_box_get_selected_rows (box);
+  g_signal_emit (widget, signals[HAS_SELECTION_CHANGED], 0,
+                 !!selected_rows);
+  g_list_free (selected_rows);
+}
+
+static void
+update_monitor_list_box_header (GtkListBoxRow *row,
+                                GtkListBoxRow *before,
+                                gpointer user_data)
+{
+  GtkWidget *header;
+
+  if (before)
+    header = gtk_separator_new (GTK_ORIENTATION_HORIZONTAL);
+  else
+    header = NULL;
+
+  gtk_list_box_row_set_header (row, header);
+}
+
+static void
+on_monitors_changed (DisplayStateTracker *display_state_tracker,
+                     ScreenCastWidget *widget)
+{
+  update_monitors_list (widget);
+}
+
+static gboolean
+add_selections (ScreenCastWidget *widget,
+                GVariantBuilder *source_selections_builder)
+{
+  GList *selected_rows;
+  GList *l;
+
+  selected_rows =
+    gtk_list_box_get_selected_rows (GTK_LIST_BOX (widget->monitor_list));
+  if (!selected_rows)
+    return FALSE;
+
+  for (l = selected_rows; l; l = l->next)
+    {
+      GtkWidget *monitor_widget = gtk_bin_get_child (l->data);
+      Monitor *monitor;
+
+      monitor = g_object_get_qdata (G_OBJECT (monitor_widget),
+                                    quark_monitor_widget_data);
+
+      g_variant_builder_add (source_selections_builder, "(us)",
+                             SCREEN_CAST_SELECTION_MONITOR,
+                             monitor_get_connector (monitor));
+    }
+  g_list_free (selected_rows);
+
+  return TRUE;
+}
+
+void
+screen_cast_widget_add_selections (ScreenCastWidget *widget,
+                                   GVariantBuilder *selections_builder)
+{
+  GVariantBuilder source_selections_builder;
+
+  g_variant_builder_init (&source_selections_builder, G_VARIANT_TYPE ("a(us)"));
+  if (!add_selections (widget, &source_selections_builder))
+    {
+      g_variant_builder_clear (&source_selections_builder);
+    }
+  else
+    {
+      g_variant_builder_add (selections_builder, "{sv}",
+                             "selected_screen_cast_sources",
+                             g_variant_builder_end (&source_selections_builder));
+    }
+}
+
+void
+screen_cast_widget_set_app_id (ScreenCastWidget *widget,
+                               const char *app_id)
+{
+  g_autofree char *heading = NULL;
+
+  if (app_id && strcmp (app_id, "") != 0)
+    {
+      g_autofree char *id = NULL;
+      g_autoptr(GAppInfo) info = NULL;
+
+      id = g_strconcat (app_id, ".desktop", NULL);
+      info = G_APP_INFO (g_desktop_app_info_new (id));
+      heading = g_strdup_printf (_("Select monitor to share with %s"),
+                                 g_app_info_get_display_name (info));
+    }
+  else
+    {
+      heading = g_strdup (_("Select monitor to share with the requesting application"));
+    }
+
+  gtk_label_set_label (GTK_LABEL (widget->monitor_heading), heading);
+}
+
+void
+screen_cast_widget_set_allow_multiple (ScreenCastWidget *widget,
+                                       gboolean multiple)
+{
+  widget->multiple = multiple;
+
+  gtk_list_box_set_selection_mode (GTK_LIST_BOX (widget->monitor_list),
+                                   multiple ? GTK_SELECTION_MULTIPLE
+                                            : GTK_SELECTION_SINGLE);
+}
+
+static void
+screen_cast_widget_finalize (GObject *object)
+{
+  ScreenCastWidget *widget = SCREEN_CAST_WIDGET (object);
+
+  g_signal_handler_disconnect (widget->display_state_tracker,
+                               widget->monitors_changed_handler_id);
+
+  G_OBJECT_CLASS (screen_cast_widget_parent_class)->finalize (object);
+}
+
+static void
+screen_cast_widget_init (ScreenCastWidget *widget)
+{
+  gtk_widget_init_template (GTK_WIDGET (widget));
+
+  screen_cast_widget_set_app_id (widget, NULL);
+  screen_cast_widget_set_allow_multiple (widget, FALSE);
+
+  gtk_list_box_set_header_func (GTK_LIST_BOX (widget->monitor_list),
+                                update_monitor_list_box_header,
+                                NULL, NULL);
+  g_signal_connect (widget->monitor_list, "row-activated",
+                    G_CALLBACK (on_row_activated),
+                    widget);
+  g_signal_connect (widget->monitor_list, "selected-rows-changed",
+                    G_CALLBACK (on_selected_rows_changed),
+                    widget);
+
+  widget->display_state_tracker = display_state_tracker_get ();
+  widget->monitors_changed_handler_id =
+    g_signal_connect (widget->display_state_tracker,
+                      "monitors-changed",
+                      G_CALLBACK (on_monitors_changed),
+                      widget);
+
+  update_monitors_list (widget);
+
+  gtk_widget_show (widget->monitor_list);
+}
+
+static void
+screen_cast_widget_class_init (ScreenCastWidgetClass *klass)
+{
+  GObjectClass *object_class = G_OBJECT_CLASS (klass);
+  GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  object_class->finalize = screen_cast_widget_finalize;
+
+  signals[HAS_SELECTION_CHANGED] = g_signal_new ("has-selection-changed",
+                                                 G_TYPE_FROM_CLASS (klass),
+                                                 G_SIGNAL_RUN_LAST,
+                                                 0,
+                                                 NULL, NULL,
+                                                 NULL,
+                                                 G_TYPE_NONE, 1,
+                                                 G_TYPE_BOOLEAN);
+
+  gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/screencastwidget.ui");
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastWidget, monitor_heading);
+  gtk_widget_class_bind_template_child (widget_class, ScreenCastWidget, monitor_list);
+
+  quark_monitor_widget_data = g_quark_from_static_string ("-monitor-widget-connector-quark");
+}
+
+void
+init_screen_cast_widget (void)
+{
+  g_type_ensure (screen_cast_widget_get_type ());
+}

--- a/src/screencastwidget.h
+++ b/src/screencastwidget.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2018 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <gtk/gtk.h>
+
+typedef enum _ScreenCastSelection
+{
+  SCREEN_CAST_SELECTION_MONITOR
+} ScreenCastSelection;
+
+typedef struct _ScreenCastWidget ScreenCastWidget;
+
+#define SCREEN_CAST_TYPE_WIDGET (screen_cast_widget_get_type ())
+G_DECLARE_FINAL_TYPE (ScreenCastWidget, screen_cast_widget,
+                      SCREEN_CAST, WIDGET, GtkBox)
+
+void init_screen_cast_widget (void);
+
+void screen_cast_widget_set_app_id (ScreenCastWidget *widget,
+                                    const char *app_id);
+
+void screen_cast_widget_set_allow_multiple (ScreenCastWidget *widget,
+                                            gboolean multiple);
+
+void screen_cast_widget_add_selections (ScreenCastWidget *widget,
+                                        GVariantBuilder *selections_builder);

--- a/src/screencastwidget.ui
+++ b/src/screencastwidget.ui
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface domain="xdg-desktop-portal-gtk">
+  <!-- interface-requires gtk+ 3.22 -->
+  <template class="ScreenCastWidget" parent="GtkBox">
+    <property name="orientation">vertical</property>
+
+    <!-- Monitor selection label -->
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="hexpand">True</property>
+        <property name="halign">start</property>
+        <child>
+          <object class="GtkLabel" id="monitor_heading">
+            <property name="visible">True</property>
+            <property name="label" translatable="yes"/>
+            <property name="xalign">0.0</property>
+            <property name="margin_bottom">12</property>
+            <attributes>
+              <attribute name="weight" value="bold"/>
+            </attributes>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <!-- List of monitors -->
+    <child>
+      <object class="GtkFrame">
+        <property name="visible">True</property>
+        <property name="valign">start</property>
+        <property name="halign">fill</property>
+        <style>
+          <class name="view" />
+        </style>
+        <child>
+          <object class="GtkStack">
+            <property name="visible">True</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="transition_type">crossfade</property>
+            <child>
+              <object class="GtkNotebook" id="notebook_view">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="show_tabs">False</property>
+                <property name="show_border">False</property>
+                <child>
+                  <object class="GtkBox" id="box3">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkListBox" id="monitor_list">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/src/session.c
+++ b/src/session.c
@@ -1,0 +1,195 @@
+
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "session.h"
+
+enum
+{
+  PROP_0,
+
+  PROP_ID,
+
+  PROP_LAST
+};
+
+static GParamSpec *obj_props[PROP_LAST];
+
+static GHashTable *sessions;
+
+static void session_skeleton_iface_init (XdpImplSessionIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (Session, session, XDP_IMPL_TYPE_SESSION_SKELETON,
+                         G_IMPLEMENT_INTERFACE (XDP_IMPL_TYPE_SESSION,
+                                                session_skeleton_iface_init))
+
+#define SESSION_GET_CLASS(o) \
+  (G_TYPE_INSTANCE_GET_CLASS ((o), session_get_type (), SessionClass))
+
+Session *
+lookup_session (const char *id)
+{
+  return g_hash_table_lookup (sessions, id);
+}
+
+gboolean
+session_export (Session *session,
+                GDBusConnection *connection,
+                GError **error)
+{
+  if (!g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (session),
+                                         connection,
+                                         session->id,
+                                         error))
+    return FALSE;
+
+  g_object_ref (session);
+  session->exported = TRUE;
+
+  return TRUE;
+}
+
+void
+session_unexport (Session *session)
+{
+  session->exported = FALSE;
+  g_dbus_interface_skeleton_unexport (G_DBUS_INTERFACE_SKELETON (session));
+  g_object_unref (session);
+}
+
+void
+session_close (Session *session)
+{
+  if (session->exported)
+    session_unexport (session);
+
+  session->closed = TRUE;
+
+  SESSION_GET_CLASS (session)->close (session);
+
+  g_object_unref (session);
+}
+
+static gboolean
+handle_close (XdpImplSession *object,
+              GDBusMethodInvocation *invocation)
+{
+  Session *session = (Session *)object;
+
+  if (!session->closed)
+    session_close (session);
+
+  xdp_impl_session_complete_close (object, invocation);
+
+  return TRUE;
+}
+
+static void
+session_skeleton_iface_init (XdpImplSessionIface *iface)
+{
+  iface->handle_close = handle_close;
+}
+
+static void
+session_set_property (GObject *object,
+                      guint prop_id,
+                      const GValue *value,
+                      GParamSpec *pspec)
+{
+  Session *session = (Session *)object;
+
+  switch (prop_id)
+    {
+    case PROP_ID:
+      session->id = g_strdup (g_value_get_string (value));
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+session_get_property (GObject *object,
+                      guint prop_id,
+                      GValue *value,
+                      GParamSpec *pspec)
+{
+  Session *session = (Session *)object;
+
+  switch (prop_id)
+    {
+    case PROP_ID:
+      g_value_set_string (value, session->id);
+      break;
+
+    default:
+      G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+    }
+}
+
+static void
+session_finalize (GObject *object)
+{
+  Session *session = (Session *)object;
+
+  g_hash_table_remove (sessions, session->id);
+
+  g_free (session->id);
+
+  G_OBJECT_CLASS (session_parent_class)->finalize (object);
+}
+
+static void
+session_constructed (GObject *object)
+{
+  Session *session = (Session *)object;
+
+  g_hash_table_insert (sessions, g_strdup (session->id), session);
+
+  G_OBJECT_CLASS (session_parent_class)->constructed (object);
+}
+
+static void
+session_init (Session *session)
+{
+}
+
+static void
+session_class_init (SessionClass *klass)
+{
+  GObjectClass *gobject_class;
+
+  gobject_class = G_OBJECT_CLASS (klass);
+  gobject_class->constructed = session_constructed;
+  gobject_class->finalize = session_finalize;
+  gobject_class->set_property = session_set_property;
+  gobject_class->get_property = session_get_property;
+
+  obj_props[PROP_ID] =
+    g_param_spec_string ("id", "id", "ID",
+                         NULL,
+                         G_PARAM_READWRITE |
+                         G_PARAM_CONSTRUCT_ONLY |
+                         G_PARAM_STATIC_STRINGS);
+
+  g_object_class_install_properties (gobject_class, PROP_LAST, obj_props);
+
+  sessions = g_hash_table_new_full (g_str_hash, g_str_equal,
+                                    g_free, NULL);
+}

--- a/src/session.h
+++ b/src/session.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "xdg-desktop-portal-dbus.h"
+
+typedef struct _Session Session;
+typedef struct _SessionClass SessionClass;
+
+struct _Session
+{
+  XdpImplSessionSkeleton parent;
+
+  gboolean exported;
+  gboolean closed;
+  char *id;
+};
+
+struct _SessionClass
+{
+  XdpImplSessionSkeletonClass parent_class;
+
+  void (*close) (Session *session);
+};
+
+GType session_get_type (void);
+
+G_DEFINE_AUTOPTR_CLEANUP_FUNC (Session, g_object_unref)
+
+Session *lookup_session (const char *id);
+
+Session *session_new (const char *id);
+
+void session_close (Session *session);
+
+gboolean session_export (Session *session,
+                         GDBusConnection *connection,
+                         GError **error);
+
+void session_unexport (Session *session);

--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -50,6 +50,7 @@
 #include "access.h"
 #include "account.h"
 #include "email.h"
+#include "screencast.h"
 
 
 static GMainLoop *loop = NULL;
@@ -133,6 +134,12 @@ on_bus_acquired (GDBusConnection *connection,
     }
 
   if (!email_init (connection, &error))
+    {
+      g_warning ("error: %s\n", error->message);
+      g_clear_error (&error);
+    }
+
+  if (!screen_cast_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);

--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -51,6 +51,7 @@
 #include "account.h"
 #include "email.h"
 #include "screencast.h"
+#include "remotedesktop.h"
 
 
 static GMainLoop *loop = NULL;
@@ -140,6 +141,12 @@ on_bus_acquired (GDBusConnection *connection,
     }
 
   if (!screen_cast_init (connection, &error))
+    {
+      g_warning ("error: %s\n", error->message);
+      g_clear_error (&error);
+    }
+
+  if (!remote_desktop_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);

--- a/src/xdg-desktop-portal-gtk.gresource.xml
+++ b/src/xdg-desktop-portal-gtk.gresource.xml
@@ -9,6 +9,7 @@
     <file>accountdialog.ui</file>
     <file>screencastwidget.ui</file>
     <file>screencastdialog.ui</file>
+    <file>remotedesktopdialog.ui</file>
   </gresource>
 </gresources>
 

--- a/src/xdg-desktop-portal-gtk.gresource.xml
+++ b/src/xdg-desktop-portal-gtk.gresource.xml
@@ -7,6 +7,7 @@
     <file>screenshotdialog.ui</file>
     <file>screenshotdialog.css</file>
     <file>accountdialog.ui</file>
+    <file>screencastwidget.ui</file>
     <file>screencastdialog.ui</file>
   </gresource>
 </gresources>

--- a/src/xdg-desktop-portal-gtk.gresource.xml
+++ b/src/xdg-desktop-portal-gtk.gresource.xml
@@ -7,6 +7,7 @@
     <file>screenshotdialog.ui</file>
     <file>screenshotdialog.css</file>
     <file>accountdialog.ui</file>
+    <file>screencastdialog.ui</file>
   </gresource>
 </gresources>
 


### PR DESCRIPTION
Uses unreleased version of org.gnome.Mutter.ScreenCast and org.gnome.Mutter.RemoteDesktop. I'll post a link to the mutter branch when it's ready for consumption.