### PR TITLE
screenshot: Add a PickColor method

### DIFF
--- a/data/org.gnome.Shell.Screenshot.xml
+++ b/data/org.gnome.Shell.Screenshot.xml
@@ -124,5 +124,8 @@
       <arg type="i" direction="out" name="height"/>
     </method>
 
+    <method name="PickColor">
+      <arg type="a{sv}" direction="out" name="result"/>
+    </method>
   </interface>
 </node>


### PR DESCRIPTION
This will be used to implement a color picker for
sandboxed apps. The implementation here uses a
new gnome-shell D-Bus API.