### PR TITLE
Respect lockdown settings

### DIFF
--- a/src/appchooser.h
+++ b/src/appchooser.h
@@ -22,4 +22,4 @@
 
 #include <gio/gio.h>
 
-gboolean app_chooser_init (GDBusConnection *bus, GError **error);
+gboolean app_chooser_init (GDBusConnection *bus, GSettings *lockdown, GError **error);

--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -525,8 +525,20 @@ handle_open (XdpImplFileChooser *object,
   return TRUE;
 }
 
+static void
+lockdown_changed (GSettings *settings,
+                  const char *key,
+                  gpointer data)
+{
+  XdpImplFileChooser *impl = data;
+  gboolean disabled = g_settings_get_boolean (settings, key);
+  g_debug ("Lockdown changed for file chooser: %s = %s", key, disabled ? "true" : "false");
+  xdp_impl_file_chooser_set_save_disabled (impl, g_settings_get_boolean (settings, key));
+}
+
 gboolean
 file_chooser_init (GDBusConnection *bus,
+                   GSettings *lockdown,
                    GError **error)
 {
   GDBusInterfaceSkeleton *helper;
@@ -535,6 +547,10 @@ file_chooser_init (GDBusConnection *bus,
 
   g_signal_connect (helper, "handle-open-file", G_CALLBACK (handle_open), NULL);
   g_signal_connect (helper, "handle-save-file", G_CALLBACK (handle_open), NULL);
+
+  g_signal_connect (lockdown, "changed::disable-save-to-disk",
+                    G_CALLBACK (lockdown_changed), helper);
+  lockdown_changed (lockdown, "disable-save-to-disk", helper);
 
   if (!g_dbus_interface_skeleton_export (helper,
                                          bus,

--- a/src/filechooser.h
+++ b/src/filechooser.h
@@ -22,4 +22,4 @@
 
 #include <gio/gio.h>
 
-gboolean file_chooser_init (GDBusConnection *bus, GError **error);
+gboolean file_chooser_init (GDBusConnection *bus, GSettings *lockdown, GError **error);

--- a/src/print.c
+++ b/src/print.c
@@ -600,7 +600,6 @@ handle_prepare_print (XdpImplPrint *object,
   GtkWidget *fake_parent;
 
   sender = g_dbus_method_invocation_get_sender (invocation);
-
   request = request_new (sender, arg_app_id, arg_handle);
 
   if (arg_parent_window)
@@ -663,8 +662,20 @@ handle_prepare_print (XdpImplPrint *object,
   return TRUE;
 }
 
+static void
+lockdown_changed (GSettings *settings,
+                  const char *key,
+                  gpointer data)
+{
+  XdpImplPrint *impl = data;
+  gboolean disabled = g_settings_get_boolean (settings, key);
+  g_debug ("Lockdown changed for printing: %s = %s", key, disabled ? "true" : "false");
+  xdp_impl_print_set_disabled (impl, g_settings_get_boolean (settings, key));
+}
+
 gboolean
 print_init (GDBusConnection *bus,
+            GSettings *lockdown,
             GError **error)
 {
   GDBusInterfaceSkeleton *helper;
@@ -673,6 +684,10 @@ print_init (GDBusConnection *bus,
 
   g_signal_connect (helper, "handle-print", G_CALLBACK (handle_print), NULL);
   g_signal_connect (helper, "handle-prepare-print", G_CALLBACK (handle_prepare_print), NULL);
+
+  g_signal_connect (lockdown, "changed::disable-printing",
+                    G_CALLBACK (lockdown_changed), helper);
+  lockdown_changed (lockdown, "disable-printing", helper);
 
   if (!g_dbus_interface_skeleton_export (helper,
                                          bus,

--- a/src/print.h
+++ b/src/print.h
@@ -22,4 +22,4 @@
 
 #include <gio/gio.h>
 
-gboolean print_init (GDBusConnection *bus, GError **error);
+gboolean print_init (GDBusConnection *bus, GSettings *settings, GError **error);

--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -79,6 +79,8 @@ message_handler (const gchar *log_domain,
     g_printerr ("%s: %s\n", g_get_prgname (), message);
 }
 
+static GSettings *lockdown;
+
 static void
 on_bus_acquired (GDBusConnection *connection,
                  const gchar     *name,
@@ -86,19 +88,19 @@ on_bus_acquired (GDBusConnection *connection,
 {
   GError *error = NULL;
 
-  if (!file_chooser_init (connection, &error))
+  if (!file_chooser_init (connection, lockdown, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);
     }
 
-  if (!app_chooser_init (connection, &error))
+  if (!app_chooser_init (connection, lockdown, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);
     }
 
-  if (!print_init (connection, &error))
+  if (!print_init (connection, lockdown, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);
@@ -220,6 +222,8 @@ main (int argc, char *argv[])
       g_printerr ("No session bus: %s\n", error->message);
       return 2;
     }
+
+  lockdown = g_settings_new ("org.gnome.desktop.lockdown");
 
   owner_id = g_bus_own_name (G_BUS_TYPE_SESSION,
                              "org.freedesktop.impl.portal.desktop.gtk",


### PR DESCRIPTION
Use the GNOME lockdown settings for printing, file saving
and application handlers to set the new 'disabled' properties
on the corresponding portal backends.