### PR TITLE
Handle dialog windows being closed

### DIFF
--- a/src/accountdialog.c
+++ b/src/accountdialog.c
@@ -57,6 +57,16 @@ account_dialog_finalize (GObject *object)
   G_OBJECT_CLASS (account_dialog_parent_class)->finalize (object);
 }
 
+static gboolean
+account_dialog_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  gtk_widget_hide (dialog);
+
+  g_signal_emit (dialog, signals[DONE], 0, GTK_RESPONSE_CANCEL, NULL);
+
+  return TRUE;
+}
+
 static void
 button_clicked (GtkWidget *button,
                 AccountDialog *dialog)
@@ -208,6 +218,8 @@ account_dialog_class_init (AccountDialogClass *class)
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (class);
 
   object_class->finalize = account_dialog_finalize;
+
+  widget_class->delete_event = account_dialog_delete_event;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (class),

--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -293,6 +293,14 @@ key_press_event_cb (GtkWidget *widget,
   return GDK_EVENT_PROPAGATE;
 }
 
+static gboolean
+app_chooser_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  close_dialog (APP_CHOOSER_DIALOG (dialog), NULL);
+
+  return TRUE;
+}
+
 static void
 app_chooser_dialog_close (AppChooserDialog *dialog)
 {
@@ -307,6 +315,8 @@ app_chooser_dialog_class_init (AppChooserDialogClass *class)
   GtkBindingSet *binding_set;
 
   object_class->finalize = app_chooser_dialog_finalize;
+
+  widget_class->delete_event = app_chooser_delete_event;
 
   class->close = app_chooser_dialog_close;
 

--- a/src/remotedesktopdialog.c
+++ b/src/remotedesktopdialog.c
@@ -343,10 +343,22 @@ remote_desktop_dialog_init (RemoteDesktopDialog *dialog)
   gtk_widget_init_template (GTK_WIDGET (dialog));
 }
 
+static gboolean
+remote_desktop_dialog_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  gtk_widget_hide (dialog);
+
+  g_signal_emit (dialog, signals[DONE], 0, GTK_RESPONSE_CANCEL, NULL);
+
+  return TRUE;
+}
+
 static void
 remote_desktop_dialog_class_init (RemoteDesktopDialogClass *klass)
 {
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  widget_class->delete_event = remote_desktop_dialog_delete_event;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (klass),

--- a/src/screencastdialog.c
+++ b/src/screencastdialog.c
@@ -118,10 +118,22 @@ screen_cast_dialog_init (ScreenCastDialog *dialog)
   gtk_widget_show (dialog->screen_cast_widget);
 }
 
+static gboolean
+screen_cast_dialog_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  gtk_widget_hide (dialog);
+
+  g_signal_emit (dialog, signals[DONE], 0, GTK_RESPONSE_CANCEL, NULL);
+
+  return TRUE;
+}
+
 static void
 screen_cast_dialog_class_init (ScreenCastDialogClass *klass)
 {
   GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (klass);
+
+  widget_class->delete_event = screen_cast_dialog_delete_event;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (klass),

--- a/src/screenshotdialog.c
+++ b/src/screenshotdialog.c
@@ -359,6 +359,16 @@ screenshot_dialog_finalize (GObject *object)
   G_OBJECT_CLASS (screenshot_dialog_parent_class)->finalize (object);
 }
 
+static gboolean
+screenshot_dialog_delete_event (GtkWidget *dialog, GdkEventAny *event)
+{
+  gtk_widget_hide (dialog);
+
+  g_signal_emit (dialog, signals[DONE], 0, GTK_RESPONSE_CANCEL, NULL);
+
+  return TRUE;
+}
+
 static void
 screenshot_dialog_class_init (ScreenshotDialogClass *class)
 {
@@ -366,6 +376,8 @@ screenshot_dialog_class_init (ScreenshotDialogClass *class)
   GObjectClass *object_class = G_OBJECT_CLASS (class);
 
   object_class->finalize = screenshot_dialog_finalize;
+
+  widget_class->delete_event = screenshot_dialog_delete_event;
 
   signals[DONE] = g_signal_new ("done",
                                 G_TYPE_FROM_CLASS (class),


### PR DESCRIPTION
Dialog window closing should be handled as if the user cancelled the
operation. Add delete-event handlers to signal cancellation and hide the
dialog.