### PR TITLE
Fix an oversight in message handling

### DIFF
--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -75,9 +75,9 @@ message_handler (const gchar *log_domain,
 {
   /* Make this look like normal console output */
   if (log_level & G_LOG_LEVEL_DEBUG)
-    g_printerr ("XDP: %s\n", message);
+    printf ("XDP: %s\n", message);
   else
-    g_printerr ("%s: %s\n", g_get_prgname (), message);
+    printf ("%s: %s\n", g_get_prgname (), message);
 }
 
 static void


### PR DESCRIPTION
I didn't mean to format every message like an error.