### PR TITLE
Screen cast cursor mode

### DIFF
--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -330,20 +330,23 @@ gnome_screen_cast_session_record_selections (GnomeScreenCastSession *gnome_scree
   g_variant_iter_init (&selections_iter, selections);
   while ((selection = g_variant_iter_next_value (&selections_iter)))
     {
-      ScreenCastSelection selection_type;
+      ScreenCastSourceType source_type;
       g_autofree char *key = NULL;
 
       g_variant_get (selection, "(us)",
-                     &selection_type,
+                     &source_type,
                      &key);
 
-      switch (selection_type)
+      switch (source_type)
         {
-        case SCREEN_CAST_SELECTION_MONITOR:
+        case SCREEN_CAST_SOURCE_TYPE_MONITOR:
           if (!gnome_screen_cast_session_record_monitor (gnome_screen_cast_session,
                                                          key, error))
             return FALSE;
           break;
+        case SCREEN_CAST_SOURCE_TYPE_WINDOW:
+          g_assert_not_reached ();
+          return FALSE;
         }
     }
 

--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -250,9 +250,29 @@ gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gnome_s
     }
 }
 
+static uint32_t
+cursor_mode_to_gnome_cursor_mode (ScreenCastCursorMode cursor_mode)
+{
+  switch (cursor_mode)
+    {
+    case SCREEN_CAST_CURSOR_MODE_NONE:
+      g_assert_not_reached ();
+      return -1;
+    case SCREEN_CAST_CURSOR_MODE_HIDDEN:
+      return 0;
+    case SCREEN_CAST_CURSOR_MODE_EMBEDDED:
+      return 1;
+    case SCREEN_CAST_CURSOR_MODE_METADATA:
+      return 2;
+    }
+
+  g_assert_not_reached ();
+}
+
 static gboolean
 gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_cast_session,
                                           const char *connector,
+                                          ScreenCastSelection *select,
                                           GError **error)
 {
   OrgGnomeMutterScreenCastSession *session_proxy =
@@ -266,6 +286,15 @@ gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_c
   GVariant *parameters;
 
   g_variant_builder_init (&properties_builder, G_VARIANT_TYPE_VARDICT);
+  if (select->cursor_mode)
+    {
+      uint32_t gnome_cursor_mode;
+
+      gnome_cursor_mode = cursor_mode_to_gnome_cursor_mode (select->cursor_mode);
+      g_variant_builder_add (&properties_builder, "{sv}",
+                             "cursor-mode",
+                             g_variant_new_uint32 (gnome_cursor_mode));
+    }
   properties = g_variant_builder_end (&properties_builder);
 
   if (!org_gnome_mutter_screen_cast_session_call_record_monitor_sync (session_proxy,
@@ -322,6 +351,7 @@ gnome_screen_cast_session_record_monitor (GnomeScreenCastSession *gnome_screen_c
 gboolean
 gnome_screen_cast_session_record_selections (GnomeScreenCastSession *gnome_screen_cast_session,
                                              GVariant *selections,
+                                             ScreenCastSelection *select,
                                              GError **error)
 {
   GVariantIter selections_iter;
@@ -341,7 +371,9 @@ gnome_screen_cast_session_record_selections (GnomeScreenCastSession *gnome_scree
         {
         case SCREEN_CAST_SOURCE_TYPE_MONITOR:
           if (!gnome_screen_cast_session_record_monitor (gnome_screen_cast_session,
-                                                         key, error))
+                                                         key,
+                                                         select,
+                                                         error))
             return FALSE;
           break;
         case SCREEN_CAST_SOURCE_TYPE_WINDOW:
@@ -482,6 +514,12 @@ gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
                       gnome_screen_cast_session);
 
   return gnome_screen_cast_session;
+}
+
+int
+gnome_screen_cast_get_api_version (GnomeScreenCast *gnome_screen_cast)
+{
+  return gnome_screen_cast->api_version;
 }
 
 static void

--- a/src/gnomescreencast.h
+++ b/src/gnomescreencast.h
@@ -22,6 +22,8 @@
 #include <gio/gio.h>
 #include <stdint.h>
 
+#include "screencast.h"
+
 typedef struct _GnomeScreenCast GnomeScreenCast;
 typedef struct _GnomeScreenCastSession GnomeScreenCastSession;
 typedef struct _GnomeScreenCastStream GnomeScreenCastStream;
@@ -34,6 +36,7 @@ void gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gn
 
 gboolean gnome_screen_cast_session_record_selections (GnomeScreenCastSession *gnome_screen_cast_session,
                                                       GVariant *selections,
+                                                      ScreenCastSelection *select,
                                                       GError **error);
 
 gboolean gnome_screen_cast_session_stop (GnomeScreenCastSession *gnome_screen_cast_session,
@@ -45,5 +48,7 @@ gboolean gnome_screen_cast_session_start (GnomeScreenCastSession *gnome_screen_c
 GnomeScreenCastSession *gnome_screen_cast_create_session (GnomeScreenCast *gnome_screen_cast,
                                                           const char *remote_desktop_session_id,
                                                           GError **error);
+
+int gnome_screen_cast_get_api_version (GnomeScreenCast *gnome_screen_cast);
 
 GnomeScreenCast *gnome_screen_cast_new (GDBusConnection *connection);

--- a/src/remotedesktop.c
+++ b/src/remotedesktop.c
@@ -65,10 +65,8 @@ typedef struct _RemoteDesktopSession
   struct {
     RemoteDesktopDeviceType device_types;
 
-    struct {
-      gboolean enable;
-      gboolean multiple;
-    } screen_cast;
+    gboolean screen_cast_enable;
+    ScreenCastSelection screen_cast;
   } select;
 
   struct {
@@ -124,10 +122,10 @@ is_remote_desktop_session (Session *session)
 
 void
 remote_desktop_session_sources_selected (RemoteDesktopSession *session,
-                                         gboolean multiple)
+                                         ScreenCastSelection *selection)
 {
-  session->select.screen_cast.enable = TRUE;
-  session->select.screen_cast.multiple = multiple;
+  session->select.screen_cast_enable = TRUE;
+  session->select.screen_cast = *selection;
 }
 
 static void
@@ -238,8 +236,8 @@ create_remote_desktop_dialog (RemoteDesktopSession *session,
   dialog =
     GTK_WIDGET (remote_desktop_dialog_new (request->app_id,
                                            session->select.device_types,
-                                           session->select.screen_cast.enable,
-                                           session->select.screen_cast.multiple));
+                                           session->select.screen_cast_enable ?
+                                             &session->select.screen_cast : NULL));
   gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
   gtk_window_set_modal (GTK_WINDOW (dialog), TRUE);
 

--- a/src/remotedesktop.c
+++ b/src/remotedesktop.c
@@ -482,6 +482,7 @@ open_screen_cast_session (RemoteDesktopSession *remote_desktop_session,
 
   if (!gnome_screen_cast_session_record_selections (gnome_screen_cast_session,
                                                     source_selections,
+                                                    &remote_desktop_session->select.screen_cast,
                                                     error))
     return FALSE;
 

--- a/src/remotedesktop.h
+++ b/src/remotedesktop.h
@@ -22,6 +22,7 @@
 #include <gio/gio.h>
 
 #include "session.h"
+#include "screencast.h"
 
 typedef struct _RemoteDesktopSession RemoteDesktopSession;
 
@@ -40,7 +41,7 @@ typedef enum _RemoteDesktopDeviceType
 gboolean is_remote_desktop_session (Session *session);
 
 void remote_desktop_session_sources_selected (RemoteDesktopSession *session,
-                                              gboolean multiple);
+                                              ScreenCastSelection *select);
 
 gboolean remote_desktop_init (GDBusConnection *connection,
                               GError **error);

--- a/src/remotedesktopdialog.h
+++ b/src/remotedesktopdialog.h
@@ -20,11 +20,12 @@
 
 #include <gtk/gtk.h>
 
+#include "screencast.h"
+
 #define REMOTE_DESKTOP_TYPE_DIALOG (remote_desktop_dialog_get_type ())
 G_DECLARE_FINAL_TYPE (RemoteDesktopDialog, remote_desktop_dialog,
                       REMOTE_DESKTOP, DIALOG, GtkWindow)
 
 RemoteDesktopDialog * remote_desktop_dialog_new (const char *app_id,
                                                  RemoteDesktopDeviceType device_types,
-                                                 gboolean screen_cast_enable,
-                                                 gboolean screen_cast_multiple);
+                                                 ScreenCastSelection *screen_cast_select);

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -37,13 +37,6 @@
 
 typedef struct _ScreenCastDialogHandle ScreenCastDialogHandle;
 
-typedef enum _ScreenCastSourceType
-{
-  SCREEN_CAST_SOURCE_TYPE_ANY,
-  SCREEN_CAST_SOURCE_TYPE_MONITOR,
-  SCREEN_CAST_SOURCE_TYPE_WINDOW,
-} ScreenCastSourceType;
-
 typedef struct _ScreenCastSession
 {
   Session parent;

--- a/src/screencast.h
+++ b/src/screencast.h
@@ -21,5 +21,11 @@
 #include <glib.h>
 #include <gio/gio.h>
 
+typedef enum _ScreenCastSourceType
+{
+  SCREEN_CAST_SOURCE_TYPE_MONITOR = 1,
+  SCREEN_CAST_SOURCE_TYPE_WINDOW = 2,
+} ScreenCastSourceType;
+
 gboolean screen_cast_init (GDBusConnection *connection,
                            GError **error);

--- a/src/screencast.h
+++ b/src/screencast.h
@@ -27,5 +27,10 @@ typedef enum _ScreenCastSourceType
   SCREEN_CAST_SOURCE_TYPE_WINDOW = 2,
 } ScreenCastSourceType;
 
+typedef struct _ScreenCastSelection
+{
+  gboolean multiple;
+} ScreenCastSelection;
+
 gboolean screen_cast_init (GDBusConnection *connection,
                            GError **error);

--- a/src/screencast.h
+++ b/src/screencast.h
@@ -27,9 +27,18 @@ typedef enum _ScreenCastSourceType
   SCREEN_CAST_SOURCE_TYPE_WINDOW = 2,
 } ScreenCastSourceType;
 
+typedef enum _ScreenCastCursorMode
+{
+  SCREEN_CAST_CURSOR_MODE_NONE = 0,
+  SCREEN_CAST_CURSOR_MODE_HIDDEN = 1,
+  SCREEN_CAST_CURSOR_MODE_EMBEDDED = 2,
+  SCREEN_CAST_CURSOR_MODE_METADATA = 4,
+} ScreenCastCursorMode;
+
 typedef struct _ScreenCastSelection
 {
   gboolean multiple;
+  ScreenCastCursorMode cursor_mode;
 } ScreenCastSelection;
 
 gboolean screen_cast_init (GDBusConnection *connection,

--- a/src/screencastdialog.c
+++ b/src/screencastdialog.c
@@ -95,7 +95,7 @@ on_has_selection_changed (ScreenCastWidget *screen_cast_widget,
 
 ScreenCastDialog *
 screen_cast_dialog_new (const char *app_id,
-                        gboolean multiple)
+                        ScreenCastSelection *select)
 {
   ScreenCastDialog *dialog;
   ScreenCastWidget *screen_cast_widget;
@@ -103,7 +103,7 @@ screen_cast_dialog_new (const char *app_id,
   dialog = g_object_new (SCREEN_CAST_TYPE_DIALOG, NULL);
   screen_cast_widget = SCREEN_CAST_WIDGET (dialog->screen_cast_widget);
   screen_cast_widget_set_app_id (screen_cast_widget, app_id);
-  screen_cast_widget_set_allow_multiple (screen_cast_widget, multiple);
+  screen_cast_widget_set_allow_multiple (screen_cast_widget, select->multiple);
 
   return dialog;
 }

--- a/src/screencastdialog.h
+++ b/src/screencastdialog.h
@@ -20,9 +20,11 @@
 
 #include <gtk/gtk.h>
 
+#include "screencast.h"
+
 #define SCREEN_CAST_TYPE_DIALOG (screen_cast_dialog_get_type ())
 G_DECLARE_FINAL_TYPE (ScreenCastDialog, screen_cast_dialog,
                       SCREEN_CAST, DIALOG, GtkWindow)
 
 ScreenCastDialog * screen_cast_dialog_new (const char *app_id,
-                                           gboolean multiple);
+                                           ScreenCastSelection *select);

--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -200,7 +200,7 @@ add_selections (ScreenCastWidget *widget,
                                     quark_monitor_widget_data);
 
       g_variant_builder_add (source_selections_builder, "(us)",
-                             SCREEN_CAST_SELECTION_MONITOR,
+                             SCREEN_CAST_SOURCE_TYPE_MONITOR,
                              monitor_get_connector (monitor));
     }
   g_list_free (selected_rows);

--- a/src/screencastwidget.h
+++ b/src/screencastwidget.h
@@ -20,10 +20,7 @@
 
 #include <gtk/gtk.h>
 
-typedef enum _ScreenCastSelection
-{
-  SCREEN_CAST_SELECTION_MONITOR
-} ScreenCastSelection;
+#include "screencast.h"
 
 typedef struct _ScreenCastWidget ScreenCastWidget;
 


### PR DESCRIPTION
To let the API user select between embedding, hiding or sending cursor data as pipewire metadata.