### PR TITLE
lockdown: Use the right property name

### DIFF
--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -62,7 +62,7 @@ lockdown_init (GDBusConnection *bus,
   if (g_settings_schema_has_key (schema, "disable-microphone"))
     g_settings_bind (privacy, "disable-microphone", helper, "disable-sound-output", G_SETTINGS_BIND_DEFAULT);
   if (g_settings_schema_has_key (schema, "disable-sound-output"))
-    g_settings_bind (privacy, "disable-sound-output", helper, "disable-sound", G_SETTINGS_BIND_DEFAULT);
+    g_settings_bind (privacy, "disable-sound-output", helper, "disable-sound-output", G_SETTINGS_BIND_DEFAULT);
 
   g_settings_schema_unref (schema);
 


### PR DESCRIPTION
The property was renamed to disable-sound-output. Follow along.