### PR TITLE
appchooserdialog: Make the "more" buttons circles

### DIFF
--- a/src/appchooserdialog.ui
+++ b/src/appchooserdialog.ui
@@ -100,6 +100,7 @@
                     <signal name="clicked" handler="more_clicked"/>
                     <style>
                       <class name="circular"/>
+                      <class name="image-button"/>
                       <class name="more"/>
                     </style>
                     <child>
@@ -196,6 +197,7 @@
                 <signal name="clicked" handler="more2_clicked"/>
                 <style>
                   <class name="circular"/>
+                  <class name="image-button"/>
                   <class name="more"/>
                 </style>
                 <child>


### PR DESCRIPTION
Give the "image-button" class to the "more" buttons to make them have a
1:1 aspect ratio, hence making them circles and not pill-shaped.

Before:

![appchooser-before](https://user-images.githubusercontent.com/2536339/62409370-6bef8980-b5d6-11e9-9f81-54f88cd1eb0c.png)

After:

![appchooser-after](https://user-images.githubusercontent.com/2536339/62409371-6f831080-b5d6-11e9-8306-3480863e15b2.png)