### PR TITLE
Fix crash with unsupported ScreenCast API version

### DIFF
--- a/src/screencast.c
+++ b/src/screencast.c
@@ -424,7 +424,11 @@ start_session (ScreenCastSession *screen_cast_session,
   gnome_api_version = gnome_screen_cast_get_api_version (gnome_screen_cast);
   if (gnome_api_version < SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION)
     {
-      g_warning ("org.gnome.Mutter.ScreenCast API version not compatible");
+      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR,
+                   XDG_DESKTOP_PORTAL_ERROR_FAILED,
+                   "org.gnome.Mutter.ScreenCast API version %d lower "
+                   "than minimum supported version %d",
+                   gnome_api_version, SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION);
       g_clear_object (&gnome_screen_cast);
       return FALSE;
     }


### PR DESCRIPTION
If the ScreenCast API has an unsupported version we return FALSE from `start_session` but without setting the `error` parameter. This then segfaults when we try to print the failure message here:

```c
  if (!start_session (dialog_handle->session, selections, &error))
    {
      g_warning ("Failed to start session: %s", error->message);
      response = 2;
    }
```

Also added the actual and supported API versions to the error message.