### PR TITLE
settings: disable animations when remote

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_SUBST([DBUS_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir dbus-1`]
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 
-PKG_CHECK_MODULES(GTK, [xdg-desktop-portal >= 1.0 glib-2.0 >= 2.44 gio-unix-2.0 gtk+-3.0 >= 3.14 gtk+-unix-print-3.0])
+PKG_CHECK_MODULES(GTK, [xdg-desktop-portal >= 1.0 glib-2.0 >= 2.44 gio-unix-2.0 gtk+-3.0 >= 3.14 gtk+-unix-print-3.0 fontconfig])
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)
 

--- a/data/gtk.portal
+++ b/data/gtk.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.gtk
-Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Background;
+Interfaces=org.freedesktop.impl.portal.FileChooser;org.freedesktop.impl.portal.AppChooser;org.freedesktop.impl.portal.Print;org.freedesktop.impl.portal.Screenshot;org.freedesktop.impl.portal.Notification;org.freedesktop.impl.portal.Inhibit;org.freedesktop.impl.portal.Access;org.freedesktop.impl.portal.Account;org.freedesktop.impl.portal.Email;org.freedesktop.impl.portal.ScreenCast;org.freedesktop.impl.portal.RemoteDesktop;org.freedesktop.impl.portal.Lockdown;org.freedesktop.impl.portal.Background;org.freedesktop.impl.portal.Settings;
 UseIn=gnome

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -23,6 +23,7 @@ $(dbus_built_sources): src/Makefile.am.inc
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.RemoteDesktop.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Lockdown.xml \
 	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Background.xml \
+	 $(DESKTOP_PORTAL_INTERFACES_DIR)/org.freedesktop.impl.portal.Settings.xml \
 	$(NULL)
 
 shell_built_sources = src/shell-dbus.c src/shell-dbus.h
@@ -127,6 +128,12 @@ xdg_desktop_portal_gtk_SOURCES = \
 	src/lockdown.h				\
         src/background.c                        \
         src/background.h                        \
+        src/fc-monitor.c                        \
+        src/fc-monitor.h                        \
+        src/gsd-remote-display-manager.c        \
+        src/gsd-remote-display-manager.h        \
+        src/settings.c                          \
+        src/settings.h                          \
 	$(NULL)
 
 nodist_xdg_desktop_portal_gtk_SOURCES = \

--- a/src/fc-monitor.c
+++ b/src/fc-monitor.c
@@ -1,0 +1,323 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2008 Red Hat, Inc.
+ * Copyright (C) 2017 Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ * Author:  Behdad Esfahbod, Red Hat, Inc.
+ */
+
+/* NOTE: This file is copied from gnome-settings-daemon, please keep it in sync */
+
+#include "fc-monitor.h"
+
+#include <gio/gio.h>
+#include <fontconfig/fontconfig.h>
+
+#define TIMEOUT_MILLISECONDS 1000
+
+static void
+fontconfig_cache_update_thread (GTask *task,
+                                gpointer source_object G_GNUC_UNUSED,
+                                gpointer task_data G_GNUC_UNUSED,
+                                GCancellable *cancellable G_GNUC_UNUSED)
+{
+        if (FcConfigUptoDate (NULL)) {
+                g_task_return_boolean (task, FALSE);
+                return;
+        }
+
+        if (!FcInitReinitialize ()) {
+                g_task_return_new_error (task, G_IO_ERROR, G_IO_ERROR_FAILED,
+                                         "FcInitReinitialize failed");
+                return;
+        }
+
+        g_task_return_boolean (task, TRUE);
+}
+
+static void
+fontconfig_cache_update_async (GAsyncReadyCallback callback,
+                               gpointer user_data)
+{
+        GTask *task = g_task_new (NULL, NULL, callback, user_data);
+        g_task_run_in_thread (task, fontconfig_cache_update_thread);
+        g_object_unref (task);
+}
+
+static gboolean
+fontconfig_cache_update_finish (GAsyncResult *result,
+                                GError **error)
+{
+        return g_task_propagate_boolean (G_TASK (result), error);
+}
+
+typedef enum {
+        UPDATE_IDLE,
+        UPDATE_PENDING,
+        UPDATE_RUNNING,
+        UPDATE_RESTART,
+} UpdateState;
+
+struct _FcMonitor {
+        GObject parent_instance;
+
+        GPtrArray *monitors;
+
+        guint timeout;
+        UpdateState state;
+        gboolean notify;
+};
+
+enum {
+        SIGNAL_UPDATED,
+
+        N_SIGNALS
+};
+
+static guint signals[N_SIGNALS] = { 0, };
+
+static void fc_monitor_finalize (GObject *object);
+static void monitor_files (FcMonitor *self, FcStrList *list);
+static void stuff_changed (GFileMonitor *monitor, GFile *file, GFile *other_file,
+                           GFileMonitorEvent event_type, gpointer data);
+static void start_timeout (FcMonitor *self);
+static gboolean start_update (gpointer data);
+static void update_done (GObject *source_object, GAsyncResult *result, gpointer user_data);
+
+G_DEFINE_TYPE (FcMonitor, fc_monitor, G_TYPE_OBJECT);
+
+static void
+fc_monitor_class_init (FcMonitorClass *klass)
+{
+        GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+        object_class->finalize = fc_monitor_finalize;
+
+        signals[SIGNAL_UPDATED] = g_signal_new ("updated",
+                                                G_TYPE_FROM_CLASS (klass),
+                                                G_SIGNAL_RUN_LAST,
+                                                0,
+                                                NULL,
+                                                NULL,
+                                                NULL,
+                                                G_TYPE_NONE,
+                                                0);
+}
+
+FcMonitor *
+fc_monitor_new (void)
+{
+        return g_object_new (FC_TYPE_MONITOR, NULL);
+}
+
+static void
+fc_monitor_init (FcMonitor *self G_GNUC_UNUSED)
+{
+        FcInit ();
+}
+
+static void
+fc_monitor_finalize (GObject *object)
+{
+        FcMonitor *self = FC_MONITOR (object);
+
+        if (self->timeout)
+                g_source_remove (self->timeout);
+        self->timeout = 0;
+
+        g_clear_pointer (&self->monitors, g_ptr_array_unref);
+
+        G_OBJECT_CLASS (fc_monitor_parent_class)->finalize (object);
+}
+
+void
+fc_monitor_start (FcMonitor *self)
+{
+        g_return_if_fail (FC_IS_MONITOR (self));
+        g_return_if_fail (self->monitors == NULL);
+
+        self->monitors = g_ptr_array_new_with_free_func (g_object_unref);
+
+        monitor_files (self, FcConfigGetConfigFiles (NULL));
+        monitor_files (self, FcConfigGetFontDirs (NULL));
+}
+
+void
+fc_monitor_stop (FcMonitor *self)
+{
+        g_return_if_fail (FC_IS_MONITOR (self));
+        g_clear_pointer (&self->monitors, g_ptr_array_unref);
+}
+
+static void
+monitor_files (FcMonitor *self,
+               FcStrList *list)
+{
+        const char *str;
+
+        while ((str = (const char *) FcStrListNext (list))) {
+                GFile *file;
+                GFileMonitor *monitor;
+
+                file = g_file_new_for_path (str);
+
+                g_debug ("Monitoring %s", str);
+                monitor = g_file_monitor (file, G_FILE_MONITOR_NONE, NULL, NULL);
+
+                g_object_unref (file);
+
+                if (!monitor)
+                        continue;
+
+                g_signal_connect (monitor, "changed", G_CALLBACK (stuff_changed), self);
+
+                g_ptr_array_add (self->monitors, monitor);
+        }
+
+        FcStrListDone (list);
+}
+
+static const gchar *
+get_name (GType enum_type,
+          gint enum_value)
+{
+        GEnumClass *klass = g_type_class_ref (enum_type);
+        GEnumValue *value = g_enum_get_value (klass, enum_value);
+        const gchar *name = value ? value->value_name : "(unknown)";
+        g_type_class_unref (klass);
+        return name;
+}
+
+static void
+stuff_changed (GFileMonitor *monitor G_GNUC_UNUSED,
+               GFile *file G_GNUC_UNUSED,
+               GFile *other_file G_GNUC_UNUSED,
+               GFileMonitorEvent event_type,
+               gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+        const gchar *event_name = get_name (G_TYPE_FILE_MONITOR_EVENT, event_type);
+        char *path = g_file_get_path (file);
+
+        switch (self->state) {
+        case UPDATE_IDLE:
+                g_debug ("Got %-38s for %s: starting fontconfig update timeout", event_name, path);
+                start_timeout (self);
+                break;
+
+        case UPDATE_PENDING:
+                /* wait for quiescence */
+                g_debug ("Got %-38s for %s: restarting fontconfig update timeout", event_name, path);
+                g_source_remove (self->timeout);
+                start_timeout (self);
+                break;
+
+        case UPDATE_RUNNING:
+                g_debug ("Got %-38s for %s: restarting fontconfig update", event_name, path);
+                self->state = UPDATE_RESTART;
+                break;
+
+        case UPDATE_RESTART:
+                g_debug ("Got %-38s for %s: waiting on fontconfig update", event_name, path);
+                break;
+        }
+
+	g_free (path);
+}
+
+static void
+start_timeout (FcMonitor *self)
+{
+        self->state = UPDATE_PENDING;
+        self->timeout = g_timeout_add (TIMEOUT_MILLISECONDS, start_update, self);
+        g_source_set_name_by_id (self->timeout, "[gnome-settings-daemon] update");
+}
+
+static gboolean
+start_update (gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+
+        self->state = UPDATE_RUNNING;
+        self->timeout = 0;
+
+        g_debug ("Timeout completed: starting fontconfig update");
+        fontconfig_cache_update_async (update_done, g_object_ref (self));
+
+        return G_SOURCE_REMOVE;
+}
+
+static void
+update_done (GObject *source_object G_GNUC_UNUSED,
+             GAsyncResult *result,
+             gpointer data)
+{
+        FcMonitor *self = FC_MONITOR (data);
+        gboolean restart = self->state == UPDATE_RESTART;
+        GError *error = NULL;
+
+        self->state = UPDATE_IDLE;
+
+        if (fontconfig_cache_update_finish (result, &error)) {
+                g_debug ("Fontconfig update successful");
+                /* Remember we had a successful update even if we have to restart it */
+                self->notify = TRUE;
+        } else if (error) {
+                g_warning ("Fontconfig update failed: %s", error->message);
+                g_error_free (error);
+        } else
+                g_debug ("Fontconfig update was unnecessary");
+
+        if (restart) {
+                g_debug ("Concurrent change: restarting fontconfig update timeout");
+                start_timeout (self);
+        } else if (self->notify) {
+                self->notify = FALSE;
+
+                if (self->monitors) {
+                        fc_monitor_stop (self);
+                        fc_monitor_start (self);
+                }
+
+                /* we finish modifying self before emitting the signal,
+                 * allowing the callback to stop us if it decides to. */
+                g_signal_emit (self, signals[SIGNAL_UPDATED], 0);
+        }
+
+        /* release ref taken in start_update */
+        g_object_unref (self);
+}
+
+#ifdef FONTCONFIG_MONITOR_TEST
+static void
+yay (void)
+{
+        g_message ("yay");
+}
+
+int
+main (void)
+{
+        GMainLoop *loop = g_main_loop_new (NULL, TRUE);
+        FcMonitor *monitor = fc_monitor_new ();
+
+        fc_monitor_start (monitor);
+        g_signal_connect (monitor, "updated", G_CALLBACK (yay), NULL);
+
+        g_main_loop_run (loop);
+        return 0;
+}
+#endif

--- a/src/fc-monitor.h
+++ b/src/fc-monitor.h
@@ -1,0 +1,38 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2017 Jan Alexander Steffens (heftig) <jan.steffens@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+#ifndef FC_MONITOR_H
+#define FC_MONITOR_H
+
+/* NOTE: this file is copied from gnome-settings-daemon, please keep it in sync */
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+#define FC_TYPE_MONITOR (fc_monitor_get_type ())
+G_DECLARE_FINAL_TYPE (FcMonitor, fc_monitor, FC, MONITOR, GObject)
+
+FcMonitor *fc_monitor_new (void);
+
+void fc_monitor_start (FcMonitor *monitor);
+void fc_monitor_stop  (FcMonitor *monitor);
+
+G_END_DECLS
+
+#endif /* FC_MONITOR_H */

--- a/src/gsd-remote-display-manager.c
+++ b/src/gsd-remote-display-manager.c
@@ -1,0 +1,295 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2012 Bastien Nocera <hadess@hadess.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <string.h>
+#include <errno.h>
+
+#include <locale.h>
+
+#include <glib.h>
+#include <glib/gi18n.h>
+#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
+#include <X11/Xatom.h>
+
+#include "gsd-remote-display-manager.h"
+
+enum
+{
+    PROP_0,
+    PROP_FORCE_DISABLE_ANIMATIONS
+};
+
+struct _GsdRemoteDisplayManager {
+        GObject parent;
+
+        /* Proxy for the force-disable-animations property */
+        gboolean      disabled;
+
+        GDBusProxy   *vino_proxy;
+        GCancellable *cancellable;
+        guint         vino_watch_id;
+        gboolean      vnc_in_use;
+};
+
+static void     gsd_remote_display_manager_class_init  (GsdRemoteDisplayManagerClass *klass);
+static void     gsd_remote_display_manager_init        (GsdRemoteDisplayManager      *remote_display_manager);
+
+G_DEFINE_TYPE (GsdRemoteDisplayManager, gsd_remote_display_manager, G_TYPE_OBJECT)
+
+static void
+update_property_from_variant (GsdRemoteDisplayManager *manager,
+                              GVariant                *variant)
+{
+        manager->vnc_in_use = g_variant_get_boolean (variant);
+        manager->disabled = manager->vnc_in_use;
+
+        g_debug ("%s because of remote display status (vnc: %d)",
+                 manager->disabled ? "Disabling" : "Enabling",
+                 manager->vnc_in_use);
+        g_object_notify (G_OBJECT (manager), "force-disable-animations");
+}
+
+static void
+props_changed (GDBusProxy              *proxy,
+               GVariant                *changed_properties,
+               GStrv                    invalidated_properties,
+               GsdRemoteDisplayManager *manager)
+{
+        GVariant *v;
+
+        v = g_variant_lookup_value (changed_properties, "Connected", G_VARIANT_TYPE_BOOLEAN);
+        if (v) {
+                g_debug ("Received connected change");
+                update_property_from_variant (manager, v);
+                g_variant_unref (v);
+        }
+}
+
+static void
+got_vino_proxy (GObject                 *source_object,
+                GAsyncResult            *res,
+                GsdRemoteDisplayManager *manager)
+{
+        GError *error = NULL;
+        GVariant *v;
+
+        manager->vino_proxy = g_dbus_proxy_new_finish (res, &error);
+        if (manager->vino_proxy == NULL) {
+                g_warning ("Failed to get Vino's D-Bus proxy: %s", error->message);
+                g_error_free (error);
+                return;
+        }
+
+        g_signal_connect (manager->vino_proxy, "g-properties-changed",
+                          G_CALLBACK (props_changed), manager);
+
+        v = g_dbus_proxy_get_cached_property (manager->vino_proxy, "Connected");
+        if (v) {
+                g_debug ("Setting original state");
+                update_property_from_variant (manager, v);
+                g_variant_unref (v);
+        }
+}
+
+static void
+vino_appeared_cb (GDBusConnection         *connection,
+                  const gchar             *name,
+                  const gchar             *name_owner,
+                  GsdRemoteDisplayManager *manager)
+{
+        g_debug ("Vino appeared");
+        g_dbus_proxy_new (connection,
+                          G_DBUS_PROXY_FLAGS_NONE,
+                          NULL,
+                          name,
+                          "/org/gnome/vino/screens/0",
+                          "org.gnome.VinoScreen",
+                          manager->cancellable,
+                          (GAsyncReadyCallback) got_vino_proxy,
+                          manager);
+}
+
+static void
+vino_vanished_cb (GDBusConnection         *connection,
+                  const char              *name,
+                  GsdRemoteDisplayManager *manager)
+{
+        g_debug ("Vino vanished");
+        if (manager->cancellable != NULL) {
+                g_cancellable_cancel (manager->cancellable);
+                g_clear_object (&manager->cancellable);
+        }
+        g_clear_object (&manager->vino_proxy);
+
+        /* And reset for us to have animations */
+        manager->disabled = FALSE;
+        g_object_notify (G_OBJECT (manager), "force-disable-animations");
+}
+
+static gboolean
+gsd_display_has_extension (const gchar *ext)
+{
+        int op, event, error;
+        GdkDisplay *display;
+
+        display = gdk_display_get_default ();
+        if (!GDK_IS_X11_DISPLAY (display))
+                return FALSE;
+
+        return XQueryExtension (gdk_x11_get_default_xdisplay (),
+                                ext, &op, &event, &error);
+}
+
+static gboolean
+gsd_display_has_llvmpipe (void)
+{
+        glong is_software_rendering_atom;
+        Atom type;
+        gint format;
+        gulong nitems;
+        gulong bytes_after;
+        guchar *data;
+        GdkDisplay *display;
+
+        if (g_getenv ("GSD_ignore_llvmpipe") != NULL)
+                return FALSE;
+
+        display = gdk_display_get_default ();
+        if (!GDK_IS_X11_DISPLAY (display))
+                return FALSE;
+
+        is_software_rendering_atom = gdk_x11_get_xatom_by_name_for_display (display, "_GNOME_IS_SOFTWARE_RENDERING");
+        gdk_x11_display_error_trap_push (display);
+        XGetWindowProperty (GDK_DISPLAY_XDISPLAY (display),  gdk_x11_get_default_root_xwindow (),
+                            is_software_rendering_atom,
+                            0, G_MAXLONG, False, XA_CARDINAL, &type, &format, &nitems,
+                            &bytes_after, &data);
+        gdk_x11_display_error_trap_pop_ignored (display);
+
+        if (type == XA_CARDINAL) {
+               glong *is_accelerated_ptr = (glong*) data;
+
+               return (*is_accelerated_ptr == 1);
+        }
+
+        return FALSE;
+}
+
+static void
+gsd_remote_display_manager_get_property (GObject    *object,
+                                         guint       prop_id,
+                                         GValue     *value,
+                                         GParamSpec *pspec)
+{
+        GsdRemoteDisplayManager *manager;
+
+        manager = GSD_REMOTE_DISPLAY_MANAGER (object);
+
+        switch (prop_id) {
+        case PROP_FORCE_DISABLE_ANIMATIONS:
+                g_value_set_boolean (value, manager->disabled);
+                break;
+
+        default:
+                G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+                break;
+        }
+}
+
+static void
+gsd_remote_display_manager_panel_finalize (GObject *object)
+{
+        GsdRemoteDisplayManager *manager = GSD_REMOTE_DISPLAY_MANAGER (object);
+        g_debug ("Stopping remote_display manager");
+
+        if (manager->vino_watch_id > 0) {
+                g_bus_unwatch_name (manager->vino_watch_id);
+                manager->vino_watch_id = 0;
+        }
+
+        if (manager->cancellable != NULL) {
+                g_cancellable_cancel (manager->cancellable);
+                g_clear_object (&manager->cancellable);
+        }
+        g_clear_object (&manager->vino_proxy);
+}
+
+static void
+gsd_remote_display_manager_class_init (GsdRemoteDisplayManagerClass *klass)
+{
+        GObjectClass    *object_class = G_OBJECT_CLASS (klass);
+        GParamSpec      *pspec;
+
+        object_class->get_property = gsd_remote_display_manager_get_property;
+        object_class->finalize = gsd_remote_display_manager_panel_finalize;
+
+        pspec = g_param_spec_boolean ("force-disable-animations",
+                                      "Force disable animations",
+                                      "Force disable animations",
+                                      FALSE,
+                                      G_PARAM_READABLE);
+        g_object_class_install_property (object_class, PROP_FORCE_DISABLE_ANIMATIONS, pspec);
+}
+
+static void
+gsd_remote_display_manager_init (GsdRemoteDisplayManager *manager)
+{
+
+        manager->cancellable = g_cancellable_new ();
+
+        g_debug ("Starting remote-display manager");
+
+        /* Xvnc exposes an extension named VNC-EXTENSION */
+        if (gsd_display_has_extension ("VNC-EXTENSION")) {
+                g_debug ("Disabling animations because VNC-EXTENSION was detected");
+                manager->disabled = TRUE;
+                g_object_notify (G_OBJECT (manager), "force-disable-animations");
+                return;
+        }
+
+	/* disable animations if running under llvmpipe */
+	if (gsd_display_has_llvmpipe ()) {
+		g_debug ("Disabling animations because llvmpipe was detected");
+		manager->disabled = TRUE;
+		g_object_notify (G_OBJECT (manager), "force-disable-animations");
+		return;
+	}
+
+        /* Monitor Vino's usage */
+        manager->vino_watch_id = g_bus_watch_name (G_BUS_TYPE_SESSION,
+                                                   "org.gnome.Vino",
+                                                   G_BUS_NAME_WATCHER_FLAGS_NONE,
+                                                   (GBusNameAppearedCallback) vino_appeared_cb,
+                                                   (GBusNameVanishedCallback) vino_vanished_cb,
+                                                   manager, NULL);
+}
+
+GsdRemoteDisplayManager *
+gsd_remote_display_manager_new (void)
+{
+        return GSD_REMOTE_DISPLAY_MANAGER (g_object_new (GSD_TYPE_REMOTE_DISPLAY_MANAGER, NULL));
+}

--- a/src/gsd-remote-display-manager.h
+++ b/src/gsd-remote-display-manager.h
@@ -1,0 +1,28 @@
+/* -*- Mode: C; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 8 -*-
+ *
+ * Copyright (C) 2012 Bastien Nocera <hadess@hadess.net>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "config.h"
+
+#include <glib-object.h>
+
+#define GSD_TYPE_REMOTE_DISPLAY_MANAGER            (gsd_remote_display_manager_get_type ())
+
+G_DECLARE_FINAL_TYPE (GsdRemoteDisplayManager, gsd_remote_display_manager, GSD, REMOTE_DISPLAY_MANAGER, GObject)
+
+GsdRemoteDisplayManager * gsd_remote_display_manager_new (void);

--- a/src/settings.c
+++ b/src/settings.c
@@ -1,0 +1,344 @@
+/*
+ * Copyright © 2018 Igalia S.L.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Patrick Griffis <pgriffis@igalia.com>
+ */
+
+#include "config.h"
+
+#include <time.h>
+#include <string.h>
+#include <glib/gi18n.h>
+#include <gio/gio.h>
+
+#include "settings.h"
+#include "utils.h"
+
+#include "xdg-desktop-portal-dbus.h"
+#include "fc-monitor.h"
+#include "gsd-remote-display-manager.h"
+
+static GHashTable *settings;
+static FcMonitor *fontconfig_monitor;
+static int fontconfig_serial;
+static GsdRemoteDisplayManager *remote_display;
+static gboolean enable_animations;
+
+typedef struct {
+  GSettingsSchema *schema;
+  GSettings *settings;
+} SettingsBundle;
+
+static SettingsBundle *
+settings_bundle_new (GSettingsSchema *schema,
+                     GSettings       *settings)
+{
+  SettingsBundle *bundle = g_new (SettingsBundle, 1);
+  bundle->schema = schema;
+  bundle->settings = settings;
+  return bundle;
+}
+
+static void
+settings_bundle_free (SettingsBundle *bundle)
+{
+  g_object_unref (bundle->schema);
+  g_object_unref (bundle->settings);
+  g_free (bundle);
+}
+
+static gboolean
+namespace_matches (const char         *namespace,
+                   const char * const *patterns)
+{
+  size_t i;
+
+  for (i = 0; patterns[i]; ++i)
+    {
+      size_t pattern_len;
+      const char *pattern = patterns[i];
+
+      if (pattern[0] == '\0')
+        return TRUE;
+      if (strcmp (namespace, pattern) == 0)
+        return TRUE;
+
+      pattern_len = strlen (pattern);
+      if (pattern[pattern_len - 1] == '*' && strncmp (namespace, pattern, pattern_len - 1) == 0)
+        return TRUE;
+    }
+
+  if (i == 0) /* Empty array */
+    return TRUE;
+
+  return FALSE;
+}
+
+static gboolean
+settings_handle_read_all (XdpImplSettings       *object,
+                          GDBusMethodInvocation *invocation,
+                          const char * const    *arg_namespaces,
+                          gpointer               data)
+{
+  g_autoptr(GVariantBuilder) builder = g_variant_builder_new (G_VARIANT_TYPE ("(a{sa{sv}})"));
+  GHashTableIter iter;
+  char *key;
+  SettingsBundle *value;
+
+  g_variant_builder_open (builder, G_VARIANT_TYPE ("a{sa{sv}}"));
+
+  g_hash_table_iter_init (&iter, settings);
+  while (g_hash_table_iter_next (&iter, (gpointer *)&key, (gpointer *)&value))
+    {
+      g_auto (GStrv) keys = NULL;
+      GVariantDict dict;
+      gsize i;
+
+      if (!namespace_matches (key, arg_namespaces))
+        continue;
+
+      keys = g_settings_schema_list_keys (value->schema);
+      g_variant_dict_init (&dict, NULL);
+      for (i = 0; keys[i]; ++i)
+        {
+          if (strcmp (key, "org.gnome.desktop.interface") == 0 &&
+              strcmp (keys[i], "enable-animations") == 0)
+            g_variant_dict_insert_value (&dict, keys[i], g_variant_new_boolean (enable_animations));
+          else
+            g_variant_dict_insert_value (&dict, keys[i], g_settings_get_value (value->settings, keys[i]));
+        }
+
+      g_variant_builder_add (builder, "{s@a{sv}}", key, g_variant_dict_end (&dict));
+    }
+
+  if (namespace_matches ("org.gnome.fontconfig", arg_namespaces))
+    {
+      GVariantDict dict;
+
+      g_variant_dict_init (&dict, NULL);
+      g_variant_dict_insert_value (&dict, "serial", g_variant_new_int32 (fontconfig_serial));
+
+      g_variant_builder_add (builder, "{s@a{sv}}", "org.gnome.fontconfig", g_variant_dict_end (&dict));
+    }
+
+  g_variant_builder_close (builder);
+
+  g_dbus_method_invocation_return_value (invocation, g_variant_builder_end (builder));
+
+  return TRUE;
+}
+
+static gboolean
+settings_handle_read (XdpImplSettings       *object,
+                      GDBusMethodInvocation *invocation,
+                      const char            *arg_namespace,
+                      const char            *arg_key,
+                      gpointer               data)
+{
+  g_debug ("Read %s %s", arg_namespace, arg_key);
+
+  if (strcmp (arg_namespace, "org.gnome.fontconfig") == 0)
+    {
+      if (strcmp (arg_key, "serial") == 0)
+        {
+          g_dbus_method_invocation_return_value (invocation,
+                                                 g_variant_new ("(v)", g_variant_new_int32 (fontconfig_serial)));
+          return TRUE;
+        }
+    }
+  else if (strcmp (arg_namespace, "org.gnome.desktop.interface") == 0 &&
+           strcmp (arg_key, "enable-animations") == 0)
+    {
+      g_dbus_method_invocation_return_value (invocation,
+                                             g_variant_new ("(v)", g_variant_new_boolean (enable_animations)));
+      return TRUE;
+    }
+  else if (g_hash_table_contains (settings, arg_namespace))
+    {
+      SettingsBundle *bundle = g_hash_table_lookup (settings, arg_namespace);
+      if (g_settings_schema_has_key (bundle->schema, arg_key))
+        {
+          g_autoptr (GVariant) variant = NULL;
+          variant = g_settings_get_value (bundle->settings, arg_key);
+          g_dbus_method_invocation_return_value (invocation, g_variant_new ("(v)", variant));
+          return TRUE;
+        }
+    }
+
+  g_debug ("Attempted to read unknown namespace/key pair: %s %s", arg_namespace, arg_key);
+  g_dbus_method_invocation_return_error_literal (invocation, XDG_DESKTOP_PORTAL_ERROR,
+                                                 XDG_DESKTOP_PORTAL_ERROR_NOT_FOUND,
+                                                 _("Requested setting not found"));
+
+  return TRUE;
+}
+
+typedef struct {
+  XdpImplSettings *self;
+  const char *namespace;
+} ChangedSignalUserData;
+
+static ChangedSignalUserData *
+changed_signal_user_data_new (XdpImplSettings *settings,
+                              const char      *namespace)
+{
+  ChangedSignalUserData *data = g_new (ChangedSignalUserData, 1);
+  data->self = settings;
+  data->namespace = namespace;
+  return data;
+}
+
+static void
+changed_signal_user_data_destroy (gpointer  data,
+                                  GClosure *closure)
+{
+  g_free (data);
+}
+
+static void
+on_settings_changed (GSettings             *settings,
+                     const char            *key,
+                     ChangedSignalUserData *user_data)
+{
+  g_autoptr (GVariant) new_value = g_settings_get_value (settings, key);
+
+  g_debug ("Emitting changed for %s %s", user_data->namespace, key);
+  if (strcmp (user_data->namespace, "org.gnome.desktop.interface") == 0 &&
+      strcmp (key, "enable-animations") == 0)
+    xdp_impl_settings_emit_setting_changed (user_data->self,
+                                            user_data->namespace, key,
+                                            g_variant_new ("v", g_variant_new_boolean (enable_animations)));
+  else
+    xdp_impl_settings_emit_setting_changed (user_data->self,
+                                            user_data->namespace, key,
+                                            g_variant_new ("v", new_value));
+}
+
+static void
+init_settings_table (XdpImplSettings *settings,
+                     GHashTable      *table)
+{
+  static const char * const schemas[] = {
+    "org.gnome.desktop.interface",
+    "org.gnome.settings-daemon.peripherals.mouse",
+    "org.gnome.desktop.sound",
+    "org.gnome.desktop.privacy",
+    "org.gnome.desktop.wm.preferences",
+    "org.gnome.settings-daemon.plugins.xsettings",
+    "org.gnome.desktop.a11y",
+  };
+  size_t i;
+  GSettingsSchemaSource *source = g_settings_schema_source_get_default ();
+
+  for (i = 0; i < G_N_ELEMENTS(schemas); ++i)
+    {
+      GSettings *setting;
+      GSettingsSchema *schema;
+      SettingsBundle *bundle;
+      const char *schema_name = schemas[i];
+
+      schema = g_settings_schema_source_lookup (source, schema_name, TRUE);
+      if (!schema)
+        {
+          g_debug ("%s schema not found", schema_name);
+          continue;
+        }
+
+      setting = g_settings_new (schema_name);
+      bundle = settings_bundle_new (schema, setting);
+      g_signal_connect_data (setting, "changed", G_CALLBACK(on_settings_changed),
+                             changed_signal_user_data_new (settings, schema_name),
+                             changed_signal_user_data_destroy, 0);
+      g_hash_table_insert (table, (char*)schema_name, bundle);
+    }
+}
+
+static void
+fontconfig_changed (FcMonitor       *monitor,
+                    XdpImplSettings *impl)
+{
+  const char *namespace = "org.gnome.fontconfig";
+  const char *key = "serial";
+
+  g_debug ("Emitting changed for %s %s", namespace, key);
+
+  fontconfig_serial++;
+
+  xdp_impl_settings_emit_setting_changed (impl,
+                                          namespace, key,
+                                          g_variant_new ("v", g_variant_new_int32 (fontconfig_serial)));
+}
+
+static void
+force_disable_animations_changed (GObject         *gobject,
+                                  GParamSpec      *pspec,
+                                  XdpImplSettings *impl)
+{
+  const char *namespace = "org.gnome.desktop.interface";
+  const char *key = "enable-animations";
+  gboolean force_disable;
+
+  g_object_get (gobject, "force-disable-animations", &force_disable, NULL);
+  if (force_disable)
+    enable_animations = FALSE;
+  else
+    {
+      SettingsBundle *bundle;
+
+      bundle = g_hash_table_lookup (settings, namespace);
+      enable_animations = g_settings_get_boolean (bundle->settings, key);
+    }
+
+  xdp_impl_settings_emit_setting_changed (impl,
+                                          namespace, key,
+                                          g_variant_new ("v", g_variant_new_boolean (enable_animations)));
+}
+
+gboolean
+settings_init (GDBusConnection  *bus,
+               GError          **error)
+{
+  GDBusInterfaceSkeleton *helper;
+
+  helper = G_DBUS_INTERFACE_SKELETON (xdp_impl_settings_skeleton_new ());
+
+  g_signal_connect (helper, "handle-read", G_CALLBACK (settings_handle_read), NULL);
+  g_signal_connect (helper, "handle-read-all", G_CALLBACK (settings_handle_read_all), NULL);
+
+  settings = g_hash_table_new_full (g_str_hash, g_str_equal, NULL, (GDestroyNotify)settings_bundle_free);
+
+  init_settings_table (XDP_IMPL_SETTINGS (helper), settings);
+
+  fontconfig_monitor = fc_monitor_new ();
+  g_signal_connect (fontconfig_monitor, "updated", G_CALLBACK (fontconfig_changed), helper);
+  fc_monitor_start (fontconfig_monitor);
+
+  remote_display = gsd_remote_display_manager_new ();
+  g_signal_connect (remote_display, "notify::force-disable-animations", G_CALLBACK (force_disable_animations_changed), helper);
+  force_disable_animations_changed (G_OBJECT (remote_display), NULL, XDP_IMPL_SETTINGS (helper));
+
+  if (!g_dbus_interface_skeleton_export (helper,
+                                         bus,
+                                         DESKTOP_PORTAL_OBJECT_PATH,
+                                         error))
+    return FALSE;
+
+  g_debug ("providing %s", g_dbus_interface_skeleton_get_info (helper)->name);
+
+  return TRUE;
+
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2019 Red Hat, Inc
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Authors:
+ *       Matthias Clasen <mclasen@redhat.com>
+ */
+
+#pragma once
+
+#include <gio/gio.h>
+
+gboolean settings_init (GDBusConnection *bus, GError **error);

--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -54,6 +54,7 @@
 #include "remotedesktop.h"
 #include "lockdown.h"
 #include "background.h"
+#include "settings.h"
 
 
 static GMainLoop *loop = NULL;
@@ -177,6 +178,12 @@ on_bus_acquired (GDBusConnection *connection,
     }
 
   if (!background_init (connection, &error))
+    {
+      g_warning ("error: %s\n", error->message);
+      g_clear_error (&error);
+    }
+
+  if (!settings_init (connection, &error))
     {
       g_warning ("error: %s\n", error->message);
       g_clear_error (&error);


### PR DESCRIPTION
This copies the settings code from xdg-desktop-portal to create a settings backend,

and then

applies the same logic that gnome-settings-daemon
uses to override the enable-animations setting.