### PR TITLE
screencast: Bump supported Mutter version to 3

### DIFF
--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -22,7 +22,7 @@
 
 #include <stdint.h>
 
-#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 2
+#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 3
 
 enum
 {

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -35,7 +35,7 @@
 #include "session.h"
 #include "utils.h"
 
-#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 2
+#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 3
 
 typedef struct _ScreenCastDialogHandle ScreenCastDialogHandle;
 


### PR DESCRIPTION
With the new Mutter version and the inclusion of pipewire 0.3 support
into Mutter, the reported D-Bus version for the screencast API was
bumped to 3.

Update the supported version here as well. No code changes are necessary
to make it work with the version 3 of the API.