### PR TITLE
WIP: Remove gnome-desktop dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libgnomebg"]
+	path = submodules/libgnome-bg
+	url = https://gitlab.gnome.org/hadess/libgnome-bg.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = po
+SUBDIRS = submodules/libgnome-bg po
 
 BUILT_SOURCES =
 CLEANFILES =

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,7 @@ AC_SUBST([DBUS_INTERFACES_DIR], [`$PKG_CONFIG --variable=interfaces_dir dbus-1`]
 AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 AC_SUBST([GLIB_COMPILE_RESOURCES], [`$PKG_CONFIG --variable glib_compile_resources gio-2.0`])
 
-PKG_CHECK_MODULES(GTK, [xdg-desktop-portal >= 1.5 glib-2.0 >= 2.44 gio-unix-2.0 gtk+-3.0 >= 3.14 gtk+-unix-print-3.0 fontconfig gnome-desktop-3.0 gsettings-desktop-schemas])
+PKG_CHECK_MODULES(GTK, [xdg-desktop-portal >= 1.5 glib-2.0 >= 2.44 gio-unix-2.0 gtk+-3.0 >= 3.14 gtk+-unix-print-3.0 fontconfig gsettings-desktop-schemas])
 AC_SUBST(GTK_CFLAGS)
 AC_SUBST(GTK_LIBS)
 
@@ -79,8 +79,14 @@ if test "$have_gtk_wayland" = "yes"; then
 fi
 AM_CONDITIONAL([HAVE_GTK_WAYLAND], [test "$have_gtk_wayland" = "yes"])
 
+AC_CHECK_LIBM
+AC_SUBST(LIBM)
+PKG_CHECK_MODULES([GNOME_BG], gtk+-3.0 gsettings-desktop-schemas)
+AM_CONDITIONAL(HAVE_INTROSPECTION, test "x$found_introspection" = "xyes")
+
 AC_CONFIG_FILES([
 Makefile
+submodules/libgnome-bg/Makefile
 po/Makefile.in
 ])
 AC_OUTPUT

--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -165,11 +165,12 @@ xdg_desktop_portal_gtk_SOURCES += \
 	$(NULL)
 endif
 
-xdg_desktop_portal_gtk_LDADD = $(BASE_LIBS) $(GTK_LIBS) $(GTK_X11_LIBS)
+xdg_desktop_portal_gtk_LDADD = $(BASE_LIBS) $(GTK_LIBS) $(GTK_X11_LIBS) $(top_builddir)/submodules/libgnome-bg/libgnome-bg.la
 xdg_desktop_portal_gtk_CFLAGS = $(BASE_CFLAGS) $(GTK_CFLAGS) $(GTK_X11_CFLAGS)
 xdg_desktop_portal_gtk_CPPFLAGS = \
 	-DGETTEXT_PACKAGE=\"$(GETTEXT_PACKAGE)\"        \
 	-DLOCALEDIR=\"$(localedir)\"                    \
+	-I$(top_srcdir)/submodules/libgnome-bg		\
 	-I$(top_srcdir)/src				\
 	-I$(top_builddir)/src				\
 	$(NULL)

--- a/src/wallpaperpreview.c
+++ b/src/wallpaperpreview.c
@@ -28,8 +28,7 @@
 #include <gio/gio.h>
 #include <glib/gi18n.h>
 #include <gtk/gtk.h>
-#define GNOME_DESKTOP_USE_UNSTABLE_API
-#include <libgnome-desktop/gnome-bg.h>
+#include "gnome-bg.h"
 
 #include "wallpaperpreview.h"
 
@@ -42,7 +41,6 @@ struct _WallpaperPreview {
   GtkLabel *desktop_clock_label;
   GtkWidget *drawing_area;
 
-  GnomeDesktopThumbnailFactory *thumbs;
   GnomeBG *bg;
 
   GSettings *desktop_settings;
@@ -67,7 +65,6 @@ on_preview_draw_cb (GtkWidget *widget,
 
   gtk_widget_get_allocation (GTK_WIDGET (self), &allocation);
   pixbuf = gnome_bg_create_thumbnail (self->bg,
-                                      self->thumbs,
                                       gdk_screen_get_default (),
                                       allocation.width,
                                       allocation.height);
@@ -137,7 +134,6 @@ wallpaper_preview_finalize (GObject *object)
   WallpaperPreview *self = WALLPAPER_PREVIEW (object);
 
   g_clear_object (&self->desktop_settings);
-  g_clear_object (&self->thumbs);
 
   g_clear_pointer (&self->previous_time, g_date_time_unref);
 
@@ -168,7 +164,6 @@ wallpaper_preview_init (WallpaperPreview *self)
 
   self->bg = gnome_bg_new ();
   gnome_bg_set_placement (self->bg, G_DESKTOP_BACKGROUND_STYLE_ZOOM);
-  self->thumbs = gnome_desktop_thumbnail_factory_new (GNOME_DESKTOP_THUMBNAIL_SIZE_LARGE);
 }
 
 static void


### PR DESCRIPTION
And use the libgnome-bg submodule instead.

The submodule needs to be moved to another namespace, and I've removed the thumbnailing code from it. The problem is that we would probably want _more_ of the thumbnailing code so that we always use a sandboxed image decoder, to avoid bugs in the host leading to a way to break out of the sandbox.