### PR TITLE
Use the application name in the print notification

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -31,6 +31,7 @@
 #include <gio/gunixfdlist.h>
 #include <gio/gunixinputstream.h>
 #include <gio/gunixoutputstream.h>
+#include <gio/gdesktopappinfo.h>
 
 #include "xdg-desktop-portal-dbus.h"
 
@@ -259,8 +260,27 @@ print_file (int fd,
   g_autoptr(GUnixInputStream) istream = NULL;
   g_autoptr(GUnixOutputStream) ostream = NULL;
   int fd2;
+  g_autofree char *app_desktop_fullname = NULL;
+  g_autoptr (GDesktopAppInfo) app_info = NULL;
+  // ensures the app_name won't be NULL even if the app_id.desktop file doesn't exist
+  g_autofree char *app_name = g_strdup (app_id);
 
-  title = g_strdup_printf ("Document from %s", app_id);
+  if (!g_str_has_suffix (app_id, ".desktop"))
+    {
+      app_desktop_fullname = g_strconcat (app_id, ".desktop", NULL);
+    }
+  else
+    {
+      app_desktop_fullname = g_strdup (app_id);
+    }
+
+  app_info = g_desktop_app_info_new (app_desktop_fullname);
+  if (app_info)
+    {
+      app_name = g_desktop_app_info_get_locale_string (app_info, "Name");
+    }
+
+  title = g_strdup_printf ("Document from %s", app_name);
 
   if (!preview)
     job = gtk_print_job_new (title, printer, settings, page_setup);


### PR DESCRIPTION
When printing with an application under sandbox, the notification telling that it prints says "Document from %s" where %s is the app desktop file id (i.e. will print "Document from org.gnome.Evince" with evince).

This is not very clear what this name is in the notification, particularly with a third-party app (i.e. com.github.my_beautiful_github_name.app_name).

So this changes %s to the actual translated application name, looking in the corresponding desktop file entry.

--------------------------------------------------------------------------------------------------------------

I only have one doubt about my changes. in the docs for g_desktop_app_info_new, it says that `A desktop file id is the basename of the desktop file, including the .desktop extension` (talking about the first argument, which I pass as the app_id here), but in [an other file](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/master/src/background.c#L34) only the name without .desktop is passed to the function. So should I add the .desktop to the app_id when passing or not ?

Thanks in advance :smile_cat: 