### PR TITLE
wallpaper: Drop "lockscreen" option

### DIFF
--- a/src/wallpaperdialog.h
+++ b/src/wallpaperdialog.h
@@ -25,19 +25,12 @@
 #define WALLPAPER_TYPE_DIALOG (wallpaper_dialog_get_type ())
 #define WALLPAPER_DIALOG(object) (G_TYPE_CHECK_INSTANCE_CAST (object, WALLPAPER_TYPE_DIALOG, WallpaperDialog))
 
-typedef enum {
-  BACKGROUND,
-  LOCKSCREEN,
-  BOTH
-} SetWallpaperOn;
-
 typedef struct _WallpaperDialog WallpaperDialog;
 typedef struct _WallpaperDialogClass WallpaperDialogClass;
 
 GType             wallpaper_dialog_get_type (void) G_GNUC_CONST;
 
 WallpaperDialog * wallpaper_dialog_new (const char *picture_uri,
-                                        const char *app_id,
-                                        SetWallpaperOn set_on);
+                                        const char *app_id);
 
 const gchar     * wallpaper_dialog_get_uri (WallpaperDialog *dialog);

--- a/src/wallpaperdialog.ui
+++ b/src/wallpaperdialog.ui
@@ -48,17 +48,12 @@
                 <property name="visible">True</property>
                </object>
              </child>
-             <child>
-               <object class="WallpaperPreview" id="lockscreen_preview">
-                 <property name="visible">True</property>
-                </object>
-            </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
                 <child>
                   <object class="GtkLabel">
-	            <property name="visible">True</property>
+                    <property name="visible">True</property>
                     <property name="label" translatable="yes">Failed to load image file</property>
                   </object>
                 </child>

--- a/src/wallpaperpreview.c
+++ b/src/wallpaperpreview.c
@@ -37,8 +37,8 @@ struct _WallpaperPreview {
   GtkBox parent;
 
   GtkStack *stack;
+  GtkWidget *desktop_preview;
   GtkWidget *animated_background_icon;
-  GtkLabel *lockscreen_clock_label;
   GtkLabel *desktop_clock_label;
   GtkWidget *drawing_area;
 
@@ -99,7 +99,6 @@ update_clock_label (WallpaperPreview *self,
     label = g_date_time_format (now, "%I:%M %p");
 
   gtk_label_set_label (self->desktop_clock_label, label);
-  gtk_label_set_label (self->lockscreen_clock_label, label);
 
   g_clear_pointer (&self->previous_time, g_date_time_unref);
   self->previous_time = g_steal_pointer (&now);
@@ -200,10 +199,10 @@ wallpaper_preview_class_init (WallpaperPreviewClass *klass)
   gtk_widget_class_set_template_from_resource (widget_class, "/org/freedesktop/portal/desktop/gtk/wallpaperpreview.ui");
 
   gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, stack);
+  gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, desktop_preview);
   gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, animated_background_icon);
   gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, drawing_area);
   gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, desktop_clock_label);
-  gtk_widget_class_bind_template_child (widget_class, WallpaperPreview, lockscreen_clock_label);
   gtk_widget_class_bind_template_callback (widget_class, on_preview_draw_cb);
 }
 
@@ -215,8 +214,7 @@ wallpaper_preview_new ()
 
 void
 wallpaper_preview_set_image (WallpaperPreview *self,
-                             const gchar *image_uri,
-                             gboolean is_lockscreen)
+                             const gchar *image_uri)
 {
   g_autofree char *path = NULL;
   g_autoptr(GFile) image_file = NULL;
@@ -227,8 +225,7 @@ wallpaper_preview_set_image (WallpaperPreview *self,
 
   gtk_widget_set_visible (self->animated_background_icon,
                           gnome_bg_changes_with_time (self->bg));
-
-  gtk_stack_set_visible_child_name (GTK_STACK (self->stack), is_lockscreen ? "lockscreen" : "desktop");
+  gtk_stack_set_visible_child (GTK_STACK (self->stack), self->desktop_preview);
 
   gtk_widget_queue_draw (self->drawing_area);
 }

--- a/src/wallpaperpreview.h
+++ b/src/wallpaperpreview.h
@@ -31,5 +31,4 @@ typedef struct _WallpaperPreviewClass WallpaperPreviewClass;
 GType              wallpaper_preview_get_type  (void) G_GNUC_CONST;
 
 void               wallpaper_preview_set_image (WallpaperPreview *self,
-                                                const gchar *image_uri,
-                                                gboolean is_lockscreen);
+                                                const gchar *image_uri);

--- a/src/wallpaperpreview.ui
+++ b/src/wallpaperpreview.ui
@@ -38,7 +38,7 @@
             </child>
 
             <child>
-              <object class="GtkFrame">
+              <object class="GtkFrame" id="desktop_preview">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="shadow-type">none</property>
@@ -101,31 +101,6 @@
                   </object>
                 </child>
               </object>
-              <packing>
-                <property name="name">desktop</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFrame">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="shadow-type">none</property>
-                <child>
-                  <object class="GtkLabel" id="lockscreen_clock_label">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="expand">True</property>
-                    <property name="xalign">0.5</property>
-                    <property name="yalign">0.5</property>
-                    <style>
-                      <class name="lockscreen-preview"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="name">lockscreen</property>
-              </packing>
             </child>
           </object>
         </child>


### PR DESCRIPTION
In GNOME 3.36 the lockscreen is now a blurried version of the
wallpaper. Although the gsetting for setting the lockscreen
background image will persist available, we should be consistent
with GNOME's UX decisions.

The frontend code should keep the "set-on" option, since other
desktop environments such as KDE might still have a separate
lockscreen image.

The "set-on" option will be simply ignored for the GTK backend.

See https://blogs.gnome.org/shell-dev/2020/02/18/login-and-unlock-in-gnome-shell-3-36/