### PR TITLE
background: use the same message string

### DIFF
--- a/src/background.c
+++ b/src/background.c
@@ -305,7 +305,7 @@ handle_notify_background (XdpImplBackground *object,
   g_variant_builder_init (&builder, G_VARIANT_TYPE_VARDICT);
   g_variant_builder_add (&builder, "{sv}", "title", g_variant_new_string (_("Background activity")));
 
-  body = g_strdup_printf (_("%s is running in the background."), arg_name);
+  body = g_strdup_printf (_("“%s” is running in the background"), arg_name);
   g_variant_builder_add (&builder, "{sv}", "body", g_variant_new_string (body));
   g_variant_builder_add (&builder, "{sv}", "default-action", g_variant_new_string ("show"));
 


### PR DESCRIPTION
Currently, they are two translatable strings that are almost the same, but the quotation mark.

So use the same string for both, with the quotation mark so that the name of the application is well separated from the surrounding message.

For reference, the original string is at line 215.