### PR TITLE
Fix build after 414adcac25458db38fb887d082cc52ab06ebf670

### DIFF
--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -137,7 +137,7 @@ on_image_loaded_cb (GObject *source_object,
 
   self->picture_uri = g_strdup (g_file_get_uri (tmp));
   wallpaper_preview_set_image (self->desktop_preview,
-                               self->picture_uri, FALSE);
+                               self->picture_uri);
 }
 
 WallpaperDialog *


### PR DESCRIPTION
Commit 414adcac25458db38fb887d082cc52ab06ebf670
("wallpaper: Drop "lockscreen" option (#305)", 2020-05-29)
had removed the third (gboolean) param from
the 'wallpaper_preview_set_image' function, but one call
site still passed it, so the build failed with

      CC       src/xdg_desktop_portal_gtk-wallpaperdialog.o
    src/wallpaperdialog.c: In function ‘on_image_loaded_cb’:
    src/wallpaperdialog.c:139:3: error: too many arguments to function ‘wallpaper_preview_set_image’
      139 |   wallpaper_preview_set_image (self->desktop_preview,
          |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~
    In file included from src/wallpaperdialog.c:31:
    src/wallpaperpreview.h:33:20: note: declared here
       33 | void               wallpaper_preview_set_image (WallpaperPreview *self,
          |                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~

This PR fixes the build again.