### PR TITLE
Screencast: use correct variant type

### DIFF
--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -238,7 +238,7 @@ gnome_screen_cast_session_add_stream_properties (GnomeScreenCastSession *gnome_s
 
       g_variant_builder_add (&stream_properties_builder, "{sv}",
                              "source_type",
-                             g_variant_new ("(u)", stream->source_type));
+                             g_variant_new ("u", stream->source_type));
 
       if (gnome_screen_cast_stream_get_position (stream, &x, &y))
         g_variant_builder_add (&stream_properties_builder, "{sv}",


### PR DESCRIPTION
The type for `source_type` value is [defined](https://github.com/flatpak/xdg-desktop-portal/blob/master/data/org.freedesktop.impl.portal.ScreenCast.xml#L150) as **u** and not **(u)**. 