### PR TITLE
Fix #306 X11/Qt: file portal dialog placed behind main window

### DIFF
--- a/src/externalwindow-x11.c
+++ b/src/externalwindow-x11.c
@@ -76,7 +76,7 @@ external_window_x11_new (const char *handle_str)
     }
 
   errno = 0;
-  xid = strtol (handle_str, NULL, 16);
+  xid = strtol (handle_str, NULL, 10);
   if (errno != 0)
     {
       g_warning ("Failed to reference external X11 window, invalid XID %s", handle_str);


### PR DESCRIPTION
As it says in the title. The current implementation interprets the XID of the parent_window parameter as a hexadecimal number, even though there is absolutely no mention of hexadecimal numbers in [the specification](https://flatpak.github.io/xdg-desktop-portal/portal-docs.html#parent_window). Therefore it ends up using a wrong XID to reference the window, which obviously fails and therefore prevents the file chooser window from being correctly associated with its parent window. Interpreting the XID as decimal fixes this.

Unfortunately I was only able to test this with Qt applications. For some reason I just can’t convince GTK apps to use the portal at all, they always end up showing their own file chooser no matter what.