### PR TITLE
screencast: Drop all-or-nothing API version checks

### DIFF
--- a/src/gnomescreencast.c
+++ b/src/gnomescreencast.c
@@ -22,8 +22,6 @@
 
 #include <stdint.h>
 
-#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 3
-
 enum
 {
   STREAM_SIGNAL_READY,
@@ -643,12 +641,6 @@ gnome_screen_cast_name_appeared (GDBusConnection *connection,
 
   gnome_screen_cast->api_version =
     org_gnome_mutter_screen_cast_get_version (gnome_screen_cast->proxy);
-  if (gnome_screen_cast->api_version > SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION)
-    {
-      g_warning ("org.gnome.Mutter.ScreenCast API version not compatible");
-      g_clear_object (&gnome_screen_cast->proxy);
-      return;
-    }
 
   g_signal_emit (gnome_screen_cast, signals[ENABLED], 0);
 }

--- a/src/remotedesktop.c
+++ b/src/remotedesktop.c
@@ -34,8 +34,6 @@
 #include "session.h"
 #include "utils.h"
 
-#define SUPPORTED_MUTTER_REMOTE_DESKTOP_API_VERSION 1
-
 typedef enum _GnomeRemoteDesktopDeviceType
 {
   GNOME_REMOTE_DESKTOP_DEVICE_TYPE_KEYBOARD = 1 << 0,
@@ -878,7 +876,6 @@ remote_desktop_name_appeared (GDBusConnection *connection,
                               gpointer user_data)
 {
   g_autoptr(GError) error = NULL;
-  int api_version;
   unsigned int supported_device_types;
 
   remote_desktop =
@@ -892,14 +889,6 @@ remote_desktop_name_appeared (GDBusConnection *connection,
     {
       g_warning ("Failed to acquire org.gnome.Mutter.RemoteDesktop proxy: %s",
                  error->message);
-      return;
-    }
-
-  api_version = org_gnome_mutter_remote_desktop_get_version (remote_desktop);
-  if (api_version != SUPPORTED_MUTTER_REMOTE_DESKTOP_API_VERSION)
-    {
-      g_warning ("org.gnome.Mutter.RemoteDesktop API version not compatible");
-      g_clear_object (&remote_desktop);
       return;
     }
 

--- a/src/screencast.c
+++ b/src/screencast.c
@@ -35,8 +35,6 @@
 #include "session.h"
 #include "utils.h"
 
-#define SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION 3
-
 typedef struct _ScreenCastDialogHandle ScreenCastDialogHandle;
 
 typedef struct _ScreenCastSession
@@ -415,25 +413,12 @@ start_session (ScreenCastSession *screen_cast_session,
                GError **error)
 {
   GnomeScreenCastSession *gnome_screen_cast_session;
-  int gnome_api_version;
   g_autoptr(GVariant) source_selections = NULL;
 
   gnome_screen_cast_session =
     gnome_screen_cast_create_session (gnome_screen_cast, NULL, error);
   if (!gnome_screen_cast_session)
     return FALSE;
-
-  gnome_api_version = gnome_screen_cast_get_api_version (gnome_screen_cast);
-  if (gnome_api_version < SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION)
-    {
-      g_set_error (error, XDG_DESKTOP_PORTAL_ERROR,
-                   XDG_DESKTOP_PORTAL_ERROR_FAILED,
-                   "org.gnome.Mutter.ScreenCast API version %d lower "
-                   "than minimum supported version %d",
-                   gnome_api_version, SUPPORTED_MUTTER_SCREEN_CAST_API_VERSION);
-      g_clear_object (&gnome_screen_cast);
-      return FALSE;
-    }
 
   screen_cast_session->gnome_screen_cast_session = gnome_screen_cast_session;
 


### PR DESCRIPTION
Version 4 added area recording, which we don't care about yet. No
existing API changed though, so mark version 4 as supported.