### PR TITLE
appchooserdialog: Fix warning when there's no "more row"

### DIFF
--- a/src/appchooserdialog.c
+++ b/src/appchooserdialog.c
@@ -482,7 +482,7 @@ app_chooser_dialog_update_choices (AppChooserDialog  *dialog,
 
       g_ptr_array_add (new_choices, g_strdup (choices[i]));
 
-      if (!gtk_widget_get_visible (dialog->more_row))
+      if (dialog->more_row && !gtk_widget_get_visible (dialog->more_row))
         {
           g_autofree char *desktop_id = NULL;
           g_autoptr(GAppInfo) info = NULL;


### PR DESCRIPTION
This happened trying to open a URI handled by a single application,
in this case a bjnb:// URL handled by the BlueJeans Flathub app.

```
XDP: Updating choices:
XDP: Updating choices: com.bluejeans.BlueJeans
(xdg-desktop-portal-gtk:691579): Gtk-CRITICAL **: 14:47:05.718: gtk_widget_get_visible: assertion 'GTK_IS_WIDGET (widget)' failed
```