### PR TITLE
lockdown: Bind disable-microphone to the correct property

### DIFF
--- a/src/lockdown.c
+++ b/src/lockdown.c
@@ -60,7 +60,7 @@ lockdown_init (GDBusConnection *bus,
   if (g_settings_schema_has_key (schema, "disable-camera"))
     g_settings_bind (privacy, "disable-camera", helper, "disable-camera", G_SETTINGS_BIND_DEFAULT);
   if (g_settings_schema_has_key (schema, "disable-microphone"))
-    g_settings_bind (privacy, "disable-microphone", helper, "disable-sound-output", G_SETTINGS_BIND_DEFAULT);
+    g_settings_bind (privacy, "disable-microphone", helper, "disable-microphone", G_SETTINGS_BIND_DEFAULT);
   if (g_settings_schema_has_key (schema, "disable-sound-output"))
     g_settings_bind (privacy, "disable-sound-output", helper, "disable-sound-output", G_SETTINGS_BIND_DEFAULT);
 


### PR DESCRIPTION
This being bound to disable-sound-output was causing it to not update
the disable-microphone property in the lockdown dbus interface and
caused the corresponding gsettings setting to be reset every time
xdg-desktop-portal-gtk was started.