### PR TITLE
Window sharing improvement

### DIFF
--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -83,6 +83,7 @@ create_window_widget (Window *window)
   if (icon == NULL)
     icon = g_themed_icon_new ("application-x-executable");
   window_image = gtk_image_new_from_gicon (icon, GTK_ICON_SIZE_DND);
+  gtk_image_set_pixel_size (GTK_IMAGE (window_image), 32);
   gtk_widget_set_margin_start (window_image, 12);
   gtk_widget_set_margin_end (window_image, 12);
   gtk_widget_show (window_image);


### PR DESCRIPTION
Some applications do not provide SVG icons, nor a range of icons,
only 64x64 or bigger. In these cases, even if the GtkImage is
created with the GTK_ICON_SIZE_DND (32px) hint passed, the window
icons would be bigger.

Fix that by forcing a 32px pixel size to the GtkImage.

Here's a picture of the bug:

![Captura de tela de 2021-06-04 18-54-18](https://user-images.githubusercontent.com/3518204/120868042-821b5780-c569-11eb-910f-20c8e3a29384.png)

and with this pull request:

![Captura de tela de 2021-06-04 18-54-38](https://user-images.githubusercontent.com/3518204/120868063-89dafc00-c569-11eb-9def-abdb0cde7f1e.png)
