### PR TITLE
filechooser: Avoid losing focus on X11

### DIFF
--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -651,6 +651,7 @@ handle_open (XdpImplFileChooser *object,
     }
 
   gtk_widget_show (dialog);
+  gtk_window_present (GTK_WINDOW (dialog));
 
   if (external_parent)
     external_window_set_parent_of (external_parent,


### PR DESCRIPTION
This prevents the new dialog from immediately losing focus when it opens on X11 systems.