### PR TITLE
settings: Provide org.freedesktop.appearance.color-scheme key

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -276,6 +276,7 @@ init_settings_table (XdpImplSettings *settings,
     "org.gnome.desktop.wm.preferences",
     "org.gnome.settings-daemon.plugins.xsettings",
     "org.gnome.desktop.a11y",
+    "org.gnome.desktop.a11y.interface",
     "org.gnome.desktop.input-sources",
   };
   size_t i;


### PR DESCRIPTION
See https://github.com/flatpak/xdg-desktop-portal/pull/633#issuecomment-922901502

The equivalent xdg-desktop-portal-gnome change:
https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/12