### PR TITLE
Enable settings and appchooser portals by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -87,19 +87,19 @@ AS_IF([test "x$enable_background" = "xyes"], [
 AM_CONDITIONAL([BUILD_BACKGROUND],[test "$enable_background" = "yes"])
 
 AC_ARG_ENABLE([settings],
-              [AS_HELP_STRING([--enable-settings],[Build settings portal. Needs dconf])])
-AS_IF([test "x$enable_settings" = "xyes"], [
+              [AS_HELP_STRING([--disable-settings],[Disable the settings portal, which needs dconf])])
+AS_IF([test "x$enable_settings" != "xno"], [
     PKG_CHECK_MODULES(SETTINGS, [fontconfig gsettings-desktop-schemas])
     AC_DEFINE([BUILD_SETTINGS], [1], [Define to enable settings portal])
 ])
-AM_CONDITIONAL([BUILD_SETTINGS],[test "$enable_settings" = "yes"])
+AM_CONDITIONAL([BUILD_SETTINGS],[test "$enable_settings" != "no"])
 
 AC_ARG_ENABLE([appchooser],
-              [AS_HELP_STRING([--enable-appchooser],[Build appchooser portal.])])
-AS_IF([test "x$enable_appchooser" = "xyes"], [
+              [AS_HELP_STRING([--disable-appchooser],[Disable the appchooser portal.])])
+AS_IF([test "x$enable_appchooser" != "xno"], [
     AC_DEFINE([BUILD_APPCHOOSER], [1], [Define to enable appchooser portal])
 ])
-AM_CONDITIONAL([BUILD_APPCHOOSER],[test "$enable_appchooser" = "yes"])
+AM_CONDITIONAL([BUILD_APPCHOOSER],[test "$enable_appchooser" != "no"])
 
 AC_ARG_ENABLE(lockdown,
               [AS_HELP_STRING([--enable-lockdown],[Build lockdown portal.])],


### PR DESCRIPTION
These are not redundant with the GNOME version of these portals. They
are required for GTK apps running outside GNOME. It's a little sad that
we have portals in two different places, but I think that's just how it
needs to be.

Fixes #355