### PR TITLE
notification: fix activation of default action with target

### DIFF
--- a/src/fdonotification.c
+++ b/src/fdonotification.c
@@ -424,7 +424,7 @@ fdo_add_notification (GDBusConnection *connection,
     }
 
   g_variant_lookup (notification, "default-action", "s", &n->default_action);
-  n->default_action_target = g_variant_lookup_value (notification, "default-action-target", G_VARIANT_TYPE_VARIANT);
+  n->default_action_target = g_variant_lookup_value (notification, "default-action-target", NULL);
 
   fdo_notifications = g_slist_prepend (fdo_notifications, n);
 


### PR DESCRIPTION
g_variant_lookup_value expect the internal variant type, or NULL to return the variant itself.