### PR TITLE
Don't leak app_name string if a desktop file or it's "Name" is absent

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -263,7 +263,7 @@ print_file (int fd,
   g_autofree char *app_desktop_fullname = NULL;
   g_autoptr (GDesktopAppInfo) app_info = NULL;
   // ensures the app_name won't be NULL even if the app_id.desktop file doesn't exist
-  g_autofree char *app_name = g_strdup (app_id);
+  g_autofree char *app_name = NULL;
 
   if (!g_str_has_suffix (app_id, ".desktop"))
     {
@@ -279,6 +279,9 @@ print_file (int fd,
     {
       app_name = g_desktop_app_info_get_locale_string (app_info, "Name");
     }
+
+  if (app_name == NULL)
+    app_name = g_strdup (app_id);
 
   title = g_strdup_printf ("Document from %s", app_name);
 


### PR DESCRIPTION
Note that earlier the fallback app_name may or may not have included
the .desktop extension as a suffix, depending on what was passed as
app_id to the function.  Now, it will always include the extension.

As a fallback, this shouldn't matter and being more predictable is
likely a good thing.

Fallout from 68c044c2c97261baa9b154ad29ab3ec826dd26b4