### PR TITLE
wallpaper, wallpaperdialog: Fix a few leaks pointed out by Coverity 

### DIFF
--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -196,7 +196,7 @@ handle_set_wallpaper_uri (XdpImplWallpaper *object,
 
   if (!show_preview)
     {
-      set_wallpaper (handle, g_strdup (arg_uri));
+      set_wallpaper (handle, arg_uri);
       goto out;
     }
 

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -119,7 +119,7 @@ on_image_loaded_cb (GObject *source_object,
   WallpaperDialog *self = data;
   GFileIOStream *stream = NULL;
   GFile *image_file = G_FILE (source_object);
-  GFile *tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
+  g_autoptr(GFile) tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
   g_autoptr(GError) error = NULL;
   gchar *contents = NULL;
   gsize length = 0;

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -135,7 +135,7 @@ on_image_loaded_cb (GObject *source_object,
 
   g_file_replace_contents (tmp, contents, length, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, &error);
 
-  self->picture_uri = g_strdup (g_file_get_uri (tmp));
+  self->picture_uri = g_file_get_uri (tmp);
   wallpaper_preview_set_image (self->desktop_preview,
                                self->picture_uri);
 }


### PR DESCRIPTION
These were originally detected only for `xdg-desktop-portal-gnome` because these GTK portals are disabled in Fedora land: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/42