### PR TITLE
screencastwidget: Protect against uninstalled apps

### DIFF
--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -480,7 +480,10 @@ screen_cast_widget_set_app_id (ScreenCastWidget *widget,
 
       id = g_strconcat (app_id, ".desktop", NULL);
       info = G_APP_INFO (g_desktop_app_info_new (id));
-      display_name = g_app_info_get_display_name (info);
+      if (info)
+        display_name = g_app_info_get_display_name (info);
+      else
+        display_name = app_id
       monitor_heading = g_strdup_printf (_("Select monitor to share with %s"),
                                          display_name);
       window_heading = g_strdup_printf (_("Select window to share with %s"),

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -196,7 +196,7 @@ handle_set_wallpaper_uri (XdpImplWallpaper *object,
 
   if (!show_preview)
     {
-      set_wallpaper (handle, g_strdup (arg_uri));
+      set_wallpaper (handle, arg_uri);
       goto out;
     }
 

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -119,7 +119,7 @@ on_image_loaded_cb (GObject *source_object,
   WallpaperDialog *self = data;
   GFileIOStream *stream = NULL;
   GFile *image_file = G_FILE (source_object);
-  GFile *tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
+  g_autoptr(GFile) tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
   g_autoptr(GError) error = NULL;
   gchar *contents = NULL;
   gsize length = 0;

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -135,7 +135,7 @@ on_image_loaded_cb (GObject *source_object,
 
   g_file_replace_contents (tmp, contents, length, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, &error);
 
-  self->picture_uri = g_strdup (g_file_get_uri (tmp));
+  self->picture_uri = g_file_get_uri (tmp);
   wallpaper_preview_set_image (self->desktop_preview,
                                self->picture_uri);
 }


### PR DESCRIPTION
Uninstalled apps (e.g. ones running from Builder) provide no desktop
file, which triggers a warning in the screencast widget code.

This goes on top of https://github.com/flatpak/xdg-desktop-portal-gtk/pull/386