### PR TITLE
appchooser, wallpaper, wallpaperdialog: Fix a few memory errors and missing error handling pointed out by Coverity

### DIFF
--- a/src/appchooser.c
+++ b/src/appchooser.c
@@ -125,16 +125,15 @@ handle_close (XdpImplRequest *object,
 {
   GVariantBuilder opt_builder;
 
+  if (handle->request->exported)
+    request_unexport (handle->request);
+
   g_variant_builder_init (&opt_builder, G_VARIANT_TYPE_VARDICT);
   xdp_impl_app_chooser_complete_choose_application (handle->impl,
                                                     handle->invocation,
                                                     2,
                                                     g_variant_builder_end (&opt_builder));
   app_dialog_handle_close (handle);
-
-  if (handle->request->exported)
-    request_unexport (handle->request);
-
   xdp_impl_request_complete_close (object, invocation);
 
   return TRUE;

--- a/src/screencastwidget.c
+++ b/src/screencastwidget.c
@@ -480,7 +480,10 @@ screen_cast_widget_set_app_id (ScreenCastWidget *widget,
 
       id = g_strconcat (app_id, ".desktop", NULL);
       info = G_APP_INFO (g_desktop_app_info_new (id));
-      display_name = g_app_info_get_display_name (info);
+      if (info)
+        display_name = g_app_info_get_display_name (info);
+      else
+        display_name = app_id
       monitor_heading = g_strdup_printf (_("Select monitor to share with %s"),
                                          display_name);
       window_heading = g_strdup_printf (_("Select window to share with %s"),

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -105,13 +105,17 @@ on_file_copy_cb (GObject *source_object,
     }
 
   destination = g_file_new_for_path (handle->picture_uri);
-  g_file_replace_contents (destination,
-                           contents,
-                           length,
-                           NULL, FALSE,
-                           G_FILE_CREATE_REPLACE_DESTINATION,
-                           NULL, NULL,
-                           &error);
+  if (!g_file_replace_contents (destination,
+                                contents,
+                                length,
+                                NULL, FALSE,
+                                G_FILE_CREATE_REPLACE_DESTINATION,
+                                NULL, NULL,
+                                &error))
+    {
+      g_warning ("Failed to store image as '%s': %s", handle->picture_uri, error->message);
+      goto out;
+    }
 
   if (set_gsettings (BACKGROUND_SCHEMA, handle->picture_uri))
     handle->response = 0;

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -90,7 +90,6 @@ on_file_copy_cb (GObject *source_object,
   GFile *picture_file = G_FILE (source_object);
   g_autoptr(GError) error = NULL;
   g_autofree gchar *uri = NULL;
-  g_autofree gchar *dest_path = NULL;
   gchar *contents = NULL;
   gsize length = 0;
 

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -196,7 +196,7 @@ handle_set_wallpaper_uri (XdpImplWallpaper *object,
 
   if (!show_preview)
     {
-      set_wallpaper (handle, g_strdup (arg_uri));
+      set_wallpaper (handle, arg_uri);
       goto out;
     }
 

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -119,7 +119,7 @@ on_image_loaded_cb (GObject *source_object,
   WallpaperDialog *self = data;
   GFileIOStream *stream = NULL;
   GFile *image_file = G_FILE (source_object);
-  GFile *tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
+  g_autoptr(GFile) tmp = g_file_new_tmp ("XXXXXX", &stream, NULL);
   g_autoptr(GError) error = NULL;
   gchar *contents = NULL;
   gsize length = 0;

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -135,7 +135,7 @@ on_image_loaded_cb (GObject *source_object,
 
   g_file_replace_contents (tmp, contents, length, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, &error);
 
-  self->picture_uri = g_strdup (g_file_get_uri (tmp));
+  self->picture_uri = g_file_get_uri (tmp);
   wallpaper_preview_set_image (self->desktop_preview,
                                self->picture_uri);
 }

--- a/src/wallpaperdialog.c
+++ b/src/wallpaperdialog.c
@@ -133,7 +133,11 @@ on_image_loaded_cb (GObject *source_object,
       return;
     }
 
-  g_file_replace_contents (tmp, contents, length, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, &error);
+  if (!g_file_replace_contents (tmp, contents, length, NULL, FALSE, G_FILE_CREATE_REPLACE_DESTINATION, NULL, NULL, &error))
+    {
+      g_warning ("Failed to store image: %s", error->message);
+      return;
+    }
 
   self->picture_uri = g_file_get_uri (tmp);
   wallpaper_preview_set_image (self->desktop_preview,


### PR DESCRIPTION
These were originally detected only for `xdg-desktop-portal-gnome` because these GTK portals are disabled in Fedora land: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/46

This goes on top of https://github.com/flatpak/xdg-desktop-portal-gtk/pull/387