### PR TITLE
notification: Use fdo notifictions for applications without IDs.

### DIFF
--- a/src/notification.c
+++ b/src/notification.c
@@ -229,6 +229,7 @@ handle_add_notification (XdpImplNotification *object,
 {
   if (gtk_notifications == NULL ||
       g_dbus_proxy_get_name_owner (G_DBUS_PROXY (gtk_notifications)) == NULL ||
+      !g_application_id_is_valid (arg_app_id) ||
       has_unprefixed_action (arg_notification))
     handle_add_notification_fdo (object, invocation, arg_app_id, arg_id, arg_notification);
   else


### PR DESCRIPTION
The GTK notifcation system (i.e. GNOME Shell) doesn't support notifcations without an ID and silently ignores them.
In this case, use the fdo notification system so these show.