### PR TITLE
notification: Use notification desktop-id to select backend and notify

### DIFF
--- a/src/fdonotification.c
+++ b/src/fdonotification.c
@@ -34,6 +34,7 @@ typedef struct
 {
   char *app_id;
   char *id;
+  char *desktop_id;
   guint32 notify_id;
   char *default_action;
   GVariant *default_action_target;
@@ -48,6 +49,7 @@ fdo_notification_free (gpointer data)
 
   g_free (n->app_id);
   g_free (n->id);
+  g_free (n->desktop_id);
   g_free (n->default_action);
   if (n->default_action_target)
     g_variant_unref (n->default_action_target);
@@ -264,7 +266,8 @@ call_notify (GDBusConnection *connection,
       }
 
   g_variant_builder_init (&hints_builder, G_VARIANT_TYPE ("a{sv}"));
-  g_variant_builder_add (&hints_builder, "{sv}", "desktop-entry", g_variant_new_string (fdo->app_id));
+  g_variant_builder_add (&hints_builder, "{sv}", "desktop-entry",
+                         g_variant_new_string (fdo->desktop_id ? fdo->desktop_id : fdo->app_id));
   if (g_variant_lookup (notification, "priority", "&s", &priority))
     urgency = urgency_from_priority (priority);
   else
@@ -400,6 +403,7 @@ void
 fdo_add_notification (GDBusConnection *connection,
                       const char *app_id,
                       const char *id,
+                      const char *desktop_id,
                       GVariant *notification,
                       ActivateAction activate_action,
                       gpointer data)
@@ -412,6 +416,7 @@ fdo_add_notification (GDBusConnection *connection,
       n = g_slice_new0 (FdoNotification);
       n->app_id = g_strdup (app_id);
       n->id = g_strdup (id);
+      n->desktop_id = g_strdup (desktop_id);
       n->notify_id = 0;
       n->activate_action = activate_action;
       n->data = data;

--- a/src/fdonotification.h
+++ b/src/fdonotification.h
@@ -32,6 +32,7 @@ typedef void (*ActivateAction) (GDBusConnection *connection,
 void fdo_add_notification (GDBusConnection *connection,
                            const char *app_id,
                            const char *id,
+                           const char *desktop_id,
                            GVariant *notification,
                            ActivateAction activate,
                            gpointer data);

--- a/src/notification.c
+++ b/src/notification.c
@@ -227,8 +227,13 @@ handle_add_notification (XdpImplNotification *object,
                          const gchar *arg_id,
                          GVariant *arg_notification)
 {
+  g_autofree char *name_owner = NULL;
+
+  if (gtk_notifications)
+    name_owner = g_dbus_proxy_get_name_owner (G_DBUS_PROXY (gtk_notifications));
+
   if (gtk_notifications == NULL ||
-      g_dbus_proxy_get_name_owner (G_DBUS_PROXY (gtk_notifications)) == NULL ||
+      name_owner == NULL ||
       !g_application_id_is_valid (arg_app_id) ||
       has_unprefixed_action (arg_notification))
     handle_add_notification_fdo (object, invocation, arg_app_id, arg_id, arg_notification);


### PR DESCRIPTION
This is the continuation of https://github.com/flatpak/xdg-desktop-portal/pull/904

Notifications can provide a specific desktop-id, in such case we should
just use the fdo notifications (to ensure that such info is consumed by
the shell) if the provided ID is not a FDO application ID and pass such
value to it, while when it's a valid application ID we can just use the
gtk backend to have the full experience.

When desktop-id is not provided by the portal, it means it is matching
the application-id, so we consider them the same.