### PR TITLE
Security support status: add 1.14.x, remove 1.8.x

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,8 @@ In stable branches and released packages, this table is likely to be outdated;
 please check
 [the latest version](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/master/SECURITY.md).
 
-| Version  | Supported          | Status
-| -------- | ------------------ | -------------------------------------------------------------- |
-| 1.8.x    | :white_check_mark: | Stable branch, recommended for use in distributions            |
-| <= 1.7.x | :x:                | Older branches, no longer supported                            |
+| Version   | Supported          | Status
+| --------- | ------------------ | -------------------------------------------------------------- |
+| 1.15.x    | :hammer:           | Development branch, releases may include non-security changes  |
+| 1.14.x    | :white_check_mark: | Stable branch, recommended for use in distributions            |
+| <= 1.13.x | :x:                | Older branches, no longer supported                            |


### PR DESCRIPTION
1.15.x doesn't yet exist, but when it does, it will be a development branch where security fixes might be accompanied by non-security changes that cause regressions.

I've assumed here that nobody is really maintaining 1.12.x, 1.10.x or 1.8.x. If there are CVEs, I'll have to backport fixes to 1.8.x if feasible (until Debian 11 EOL, expected in mid 2024) but I'm assuming there will not be an upstream release even if that happens.