### PR TITLE
Don't use handles after freeing them

### DIFF
--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -93,10 +93,11 @@ handle_close (XdpImplRequest        *object,
                                                       handle->invocation,
                                                       2,
                                                       g_variant_builder_end (&opt_builder));
-  install_dialog_handle_close (handle);
 
   if (handle->request->exported)
     request_unexport (handle->request);
+
+  install_dialog_handle_close (handle);
 
   xdp_impl_request_complete_close (object, invocation);
 

--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -364,10 +364,11 @@ handle_close (XdpImplRequest *object,
                                                handle->invocation,
                                                2,
                                                g_variant_builder_end (&opt_builder));
-  file_dialog_handle_close (handle);
 
   if (handle->request->exported)
     request_unexport (handle->request);
+
+  file_dialog_handle_close (handle);
 
   xdp_impl_request_complete_close (object, invocation);
 

--- a/src/print.c
+++ b/src/print.c
@@ -418,10 +418,11 @@ handle_close (XdpImplRequest *object,
                                  NULL,
                                  2,
                                  g_variant_builder_end (&opt_builder));
-  print_dialog_handle_close (handle);
 
   if (handle->request->exported)
     request_unexport (handle->request);
+
+  print_dialog_handle_close (handle);
 
   xdp_impl_request_complete_close (object, invocation);
 


### PR DESCRIPTION
The dynamic-launcher, filechooser, and print portals all use their handles after they've been freed by the call to *_handle_close(). Uh-oh.

See also: https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/issues/67