### PR TITLE
test.yml: bump actions/checkout and actions/upload-artifact to v3 to fix Node warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           make install
           cd ..
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure
         run: ./autogen.sh --disable-dependency-tracking
@@ -43,7 +43,7 @@ jobs:
         run: make install
 
       - name: Upload test logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: failure() || cancelled()
         with:
           name: test logs


### PR DESCRIPTION
## Changes

This PR bumps the version of `actions/checkout` and `actions/upload-artifact` from `v2` to `v3`. 

(Note: Upon, this PRs merge the Node 12 warning displayed under Annotations in actions will be fixed with the newer checkout version which uses Node 16). 

## Tests/Actions

A test run of the changes can be found on my fork here https://github.com/kbdharun/xdg-desktop-portal-gtk/actions/runs/4638830439