### PR TITLE
CI: Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           make install
           cd ..
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Configure
         run: ./autogen.sh --disable-dependency-tracking


### PR DESCRIPTION
This PR bumps the `actions/checkout` version from v3 (Node 16) to v4 (Node 20) as Node 16 is reaching eol soon.
Ref. https://nodejs.org/en/blog/announcements/nodejs16-eol