### PR TITLE
filechooser: Fix crash when opening a file chooser with single filter set

### DIFF
--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -557,7 +557,7 @@ handle_open (XdpImplFileChooser *object,
       g_autoptr (GtkFileFilter) filter = NULL;
       const char *current_filter_name;
 
-      filter = gtk_file_filter_new_from_gvariant (current_filter);
+      filter = g_object_ref_sink (gtk_file_filter_new_from_gvariant (current_filter));
       current_filter_name = gtk_file_filter_get_name (filter);
 
       if (!filters)


### PR DESCRIPTION
`gtk_file_filter_new_from_gvariant ()` returns a `GtkFileFilter` which is a floating reference in GTK3. `gtk_file_chooser_set_filter ()` takes ownership of this floating reference. So, we take a ref to the filter to account for the autoptr cleanup.

Note that this happens only when we have a single filter ( with 1 or more rules ) set via `gtk_file_chooser_set_filter ()` in the app.