### PR TITLE
Update versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,11 @@ org.gnome.Screensaver D-Bus interfaces.
 ## Building xdg-desktop-portal-gtk
 
 xdg-desktop-portal-gtk depends on xdg-desktop-portal and GTK.
+
+## Versioning
+
+The xdg-desktop-portal-gtk version has three components:
+
+- major, incremented for backward compatibility breaking changes
+- minor, incremented for changes in dependencies and exposed interfaces
+- micro, incremented for bug fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,5 +11,5 @@ please check
 | Version   | Supported          | Status
 | --------- | ------------------ | ----------------------------------------------------------- |
 | 1.15.x    | :white_check_mark: | Current stable branch, recommended for use in distributions |
-| 1.14.x    | :white_check_mark: | Old stable branch, will received only security fixes        |
+| 1.14.x    | :white_check_mark: | Old stable branch, will receive only security fixes         |
 | <= 1.13.x | :x:                | Older branches, no longer supported                         |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,7 +9,7 @@ please check
 [the latest version](https://github.com/flatpak/xdg-desktop-portal-gtk/blob/master/SECURITY.md).
 
 | Version   | Supported          | Status
-| --------- | ------------------ | -------------------------------------------------------------- |
-| 1.15.x    | :hammer:           | Development branch, releases may include non-security changes  |
-| 1.14.x    | :white_check_mark: | Stable branch, recommended for use in distributions            |
-| <= 1.13.x | :x:                | Older branches, no longer supported                            |
+| --------- | ------------------ | ----------------------------------------------------------- |
+| 1.15.x    | :white_check_mark: | Current stable branch, recommended for use in distributions |
+| 1.14.x    | :white_check_mark: | Old stable branch, will received only security fixes        |
+| <= 1.13.x | :x:                | Older branches, no longer supported                         |

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'xdg-desktop-portal-gtk',
   'c',
-  version: '1.14.1',
+  version: '1.15.0',
   meson_version: '>= 0.61.2',
   license: 'LGPL-2.1-or-later',
   default_options: ['warning_level=2'],


### PR DESCRIPTION
The contributors to xdg-desktop-portal-gtk discussed the versioning policy, and decided to drop the even/odd split.

Update the documentation and security policies.