### PR TITLE
Fix link to DBus docs

### DIFF
--- a/src/xdg-desktop-portal-gtk.c
+++ b/src/xdg-desktop-portal-gtk.c
@@ -240,7 +240,7 @@ main (int argc, char *argv[])
       "are used by xdg-desktop-portal to implement portals\n"
       "\n"
       "Documentation for the available D-Bus interfaces can be found at\n"
-      "https://flatpak.github.io/xdg-desktop-portal/portal-docs.html\n"
+      "https://flatpak.github.io/xdg-desktop-portal/docs/\n"
       "\n"
       "Please report issues at https://github.com/flatpak/xdg-desktop-portal-gtk/issues");
   g_option_context_add_main_entries (context, entries, NULL);


### PR DESCRIPTION
With the https://flatpak.github.io/xdg-desktop-portal/ site revamp the URL to the DBus docs changed slightly.

Avoids a 404.