### PR TITLE
notification: Set correct platform data for action activation

### DIFF
--- a/src/fdonotification.h
+++ b/src/fdonotification.h
@@ -27,6 +27,7 @@ typedef void (*ActivateAction) (GDBusConnection *connection,
                                 const char *id,
                                 const char *name,
                                 GVariant *parameter,
+                                const char *activation_token,
                                 gpointer data);
 
 void fdo_add_notification (GDBusConnection *connection,

--- a/src/notification.c
+++ b/src/notification.c
@@ -105,6 +105,7 @@ activate_action (GDBusConnection *connection,
                  const char *id,
                  const char *name,
                  GVariant *parameter,
+                 const char *activation_token,
                  gpointer data)
 {
   g_autofree char *object_path = NULL;
@@ -115,6 +116,16 @@ activate_action (GDBusConnection *connection,
   g_variant_builder_init (&parms, G_VARIANT_TYPE ("av"));
   if (parameter)
     g_variant_builder_add (&parms, "v", parameter);
+
+  if (activation_token)
+    {
+      /* Used by  `GTK` < 4.10 */
+      g_variant_builder_add (&pdata, "{sv}",
+                             "desktop-startup-id", g_variant_new_string (activation_token));
+      /* Used by `GTK` and `QT` */
+      g_variant_builder_add (&pdata, "{sv}",
+                             "activation-token", g_variant_new_string (activation_token));
+    }
 
   if (name && g_str_has_prefix (name, "app."))
     {

--- a/src/notification.c
+++ b/src/notification.c
@@ -157,6 +157,17 @@ activate_action (GDBusConnection *connection,
                               G_DBUS_CALL_FLAGS_NONE,
                               -1, NULL, NULL, NULL);
 
+      /* The application may not implement the `org.freedesktop.Application`, so
+       * also add the platform data containing the activation-token
+       * to the `ActionInvoked` signal */
+      if (activation_token)
+        {
+          g_variant_builder_init (&pdata, G_VARIANT_TYPE_VARDICT);
+          g_variant_builder_add (&pdata, "{sv}",
+                                 "activation-token", g_variant_new_string (activation_token));
+          g_variant_builder_add (&parms, "v", g_variant_builder_end (&pdata));
+        }
+
       g_dbus_connection_emit_signal (connection,
                                      NULL,
                                      "/org/freedesktop/portal/desktop",


### PR DESCRIPTION
Since [1] FDO notifications can transfer a `ActivateToken` to the client application, we can use this token to set the correct platform data to get wayland startup notification working correctly. GNOME Shell gained the feature already in [2], so this is the last piece missing to get rid of the annoying "<Application> is ready" notifications, when clicking on a notification.

We can set the platform data for actions that are activated via `org.freedesktop.Application`.
For apps that don't implement the `org.freedesktop.Application` interface we can add the
platform data to the `ActionInvoked` signal.

Fixes: https://github.com/flatpak/xdg-desktop-portal-gtk/issues/406

[1] https://gitlab.freedesktop.org/xdg/xdg-specs/-/commit/b9a470004d
[2] https://gitlab.gnome.org/GNOME/gnome-shell/-/merge_requests/3199/