### PR TITLE
settings: Update mouse schema name

### DIFF
--- a/src/settings.c
+++ b/src/settings.c
@@ -306,10 +306,10 @@ init_settings_table (XdpImplSettings *settings,
     "org.gnome.desktop.calendar",
     "org.gnome.desktop.input-sources",
     "org.gnome.desktop.interface",
+    "org.gnome.desktop.peripherals.mouse",
     "org.gnome.desktop.privacy",
     "org.gnome.desktop.sound",
     "org.gnome.desktop.wm.preferences",
-    "org.gnome.settings-daemon.peripherals.mouse",
     "org.gnome.settings-daemon.plugins.xsettings",
   };
   size_t i;


### PR DESCRIPTION
Mouse settings were moved from gnome-settings-daemon in 2015.