### PR TITLE
print: Support "supported_output_file_formats" option

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -189,6 +189,46 @@ can_preview (void)
   return FALSE;
 }
 
+static GtkPrintCapabilities
+print_capabilities_from_options (GVariant *options)
+{
+  g_auto(GStrv) supported_output_file_formats = NULL;
+  GtkPrintCapabilities capabilities;
+
+  capabilities = can_preview () ? GTK_PRINT_CAPABILITY_PREVIEW : 0 |
+                 GTK_PRINT_CAPABILITY_PAGE_SET |
+                 GTK_PRINT_CAPABILITY_COPIES |
+                 GTK_PRINT_CAPABILITY_COLLATE |
+                 GTK_PRINT_CAPABILITY_REVERSE |
+                 GTK_PRINT_CAPABILITY_SCALE |
+                 GTK_PRINT_CAPABILITY_NUMBER_UP;
+
+  if (g_variant_lookup (options, "supported_output_file_formats", "^as", &supported_output_file_formats))
+    {
+      g_autoptr(GHashTable) formats = NULL;
+
+      g_assert (supported_output_file_formats && supported_output_file_formats[0] != NULL);
+
+      formats = g_hash_table_new (g_str_hash, g_str_equal);
+
+      for (size_t i = 0; supported_output_file_formats[i]; i++)
+        g_hash_table_add (formats, (gpointer) supported_output_file_formats[i]);
+
+      /* This is a limitation of GtkPrintCapability - it doesn't have an enum
+       * for SVG files.
+       */
+      if (!g_hash_table_contains (formats, "svg"))
+        {
+          if (g_hash_table_contains (formats, "pdf"))
+            capabilities |= GTK_PRINT_CAPABILITY_GENERATE_PDF;
+          if (g_hash_table_contains (formats, "ps"))
+            capabilities |= GTK_PRINT_CAPABILITY_GENERATE_PS;
+        }
+    }
+
+  return capabilities;
+}
+
 static gboolean
 launch_preview (const char *filename,
                 const char *title,
@@ -511,14 +551,7 @@ handle_print (XdpImplPrint *object,
   gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
   gtk_window_set_modal (GTK_WINDOW (dialog), modal);
   gtk_print_unix_dialog_set_manual_capabilities (GTK_PRINT_UNIX_DIALOG (dialog),
-                                                 can_preview () ? GTK_PRINT_CAPABILITY_PREVIEW : 0 |
-						 GTK_PRINT_CAPABILITY_PAGE_SET |
-						 GTK_PRINT_CAPABILITY_COPIES |
-						 GTK_PRINT_CAPABILITY_COLLATE |
-						 GTK_PRINT_CAPABILITY_REVERSE |
-						 GTK_PRINT_CAPABILITY_SCALE |
-						 GTK_PRINT_CAPABILITY_NUMBER_UP
-						 );
+                                                 print_capabilities_from_options (arg_options));
   handle = g_new0 (PrintDialogHandle, 1);
   handle->impl = object;
   handle->invocation = invocation;
@@ -665,14 +698,7 @@ handle_prepare_print (XdpImplPrint *object,
   gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
   gtk_window_set_modal (GTK_WINDOW (dialog), modal);
   gtk_print_unix_dialog_set_manual_capabilities (GTK_PRINT_UNIX_DIALOG (dialog),
-                                                 can_preview () ? GTK_PRINT_CAPABILITY_PREVIEW : 0 |
-						 GTK_PRINT_CAPABILITY_PAGE_SET |
-						 GTK_PRINT_CAPABILITY_COPIES |
-						 GTK_PRINT_CAPABILITY_COLLATE |
-						 GTK_PRINT_CAPABILITY_REVERSE |
-						 GTK_PRINT_CAPABILITY_SCALE |
-						 GTK_PRINT_CAPABILITY_NUMBER_UP
-						 );
+                                                 print_capabilities_from_options (arg_options));
   gtk_print_unix_dialog_set_embed_page_setup (GTK_PRINT_UNIX_DIALOG (dialog), TRUE);
   gtk_print_unix_dialog_set_settings (GTK_PRINT_UNIX_DIALOG (dialog), settings);
   gtk_print_unix_dialog_set_page_setup (GTK_PRINT_UNIX_DIALOG (dialog), page_setup);


### PR DESCRIPTION
Respect the allowed output file formats set by apps.