### PR TITLE
Handle "high" priority

### DIFF
--- a/src/fdonotification.c
+++ b/src/fdonotification.c
@@ -178,7 +178,9 @@ urgency_from_priority (const char *priority)
     return 0;
   else if (strcmp (priority, "normal") == 0)
     return 1;
-  else
+  else if (strcmp (priority, "high") == 0)
+    return 1;
+  else  // critical
     return 2;
 }
 


### PR DESCRIPTION
This PR addresses an issue with the urgency level mapping for notifications. The current implementation maps notifications with "high" urgency to "critical," which is not the standard practice. This change will adjust the mapping so that "high" urgency notifications are set to "normal."

See relevant issue https://github.com/flatpak/xdg-desktop-portal-gtk/issues/439