### PR TITLE
Order startup after graphical-session.target

### DIFF
--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Portal service (GTK/GNOME implementation)
+PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
 Type=dbus

--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -1,6 +1,5 @@
 [Unit]
 Description=Portal service (GTK/GNOME implementation)
-PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]


### PR DESCRIPTION
Otherwise portal unit might try to start before compositor exported `WAYLAND_DISPLAY` to activation environments.
[Reference](https://github.com/Vladimir-csp/uwsm/issues/37#issuecomment-2307818022)