### PR TITLE
Add PartOf

### DIFF
--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -1,5 +1,6 @@
 [Unit]
 Description=Portal service (GTK/GNOME implementation)
+PartOf=graphical-session.target
 After=graphical-session.target
 
 [Service]


### PR DESCRIPTION
Sorry, I got a bit confused in previous PR and removed this line. Indeed `PartOf=graphical-session.target` is a valid and useful directive, as it ensures the unit is properly brought down when graphical session is deactivating.

This will bring `-gtk` portal unit in line with others like `-wlr` or `-hyprland`.