### PR TITLE
Place xdg-desktop-portal-gtk.service in session.slice

### DIFF
--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -6,3 +6,4 @@ After=graphical-session.target
 Type=dbus
 BusName=org.freedesktop.impl.portal.desktop.gtk
 ExecStart=@libexecdir@/xdg-desktop-portal-gtk
+Slice=session.slice


### PR DESCRIPTION
By default, systemd would place it in `app.slice` which doesn't make sense; that's where apps go, not daemons that are part of the desktop session.

`session.slice` makes a lot more sense and it's where the other xdg and/or portal services are placed too.

cc @smcv @Vladimir-csp 