### PR TITLE
Avoid failure to start during login

### DIFF
--- a/data/xdg-desktop-portal-gtk.service.in
+++ b/data/xdg-desktop-portal-gtk.service.in
@@ -1,7 +1,7 @@
 [Unit]
 Description=Portal service (GTK/GNOME implementation)
 PartOf=graphical-session.target
-After=graphical-session.target
+After=graphical-session.target basic.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
If started during login, this service exits with a warning "cannot open display: :1".  Systemd then restarts it successfully a few moments later.

Delay start until it is likely to succeed.