### PR TITLE
fdonotification: Make two functions static

### DIFF
--- a/src/fdonotification.c
+++ b/src/fdonotification.c
@@ -57,7 +57,7 @@ fdo_notification_free (gpointer data)
   g_slice_free (FdoNotification, n);
 }
 
-FdoNotification *
+static FdoNotification *
 fdo_find_notification (const char *app_id,
                        const char *id)
 {
@@ -74,7 +74,7 @@ fdo_find_notification (const char *app_id,
   return NULL;
 }
 
-FdoNotification *
+static FdoNotification *
 fdo_find_notification_by_notify_id (guint32 id)
 {
   GSList *l;


### PR DESCRIPTION
They're not used outside the compilation unit