### PR TITLE
Don't return response of 2 when the dialog is closed normally.

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -120,11 +120,10 @@ access_dialog_response (GtkWidget *widget,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       break;

--- a/src/account.c
+++ b/src/account.c
@@ -101,11 +101,10 @@ account_dialog_done (GtkWidget *widget,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       break;

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -147,11 +147,10 @@ handle_prepare_install_response (GtkDialog *dialog,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       break;

--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -226,13 +226,12 @@ file_chooser_response (GtkWidget *widget,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       handle->filter = NULL;
       handle->uris = NULL;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       handle->filter = NULL;

--- a/src/print.c
+++ b/src/print.c
@@ -384,11 +384,10 @@ handle_print_response (GtkDialog *dialog,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       break;
@@ -613,11 +612,10 @@ handle_prepare_print_response (GtkDialog *dialog,
     {
     default:
       g_warning ("Unexpected response: %d", response);
-      /* Fall through */
-    case GTK_RESPONSE_DELETE_EVENT:
       handle->response = 2;
       break;
 
+    case GTK_RESPONSE_DELETE_EVENT:
     case GTK_RESPONSE_CANCEL:
       handle->response = 1;
       break;

--- a/src/wallpaper.c
+++ b/src/wallpaper.c
@@ -159,10 +159,9 @@ handle_wallpaper_dialog_response (WallpaperDialog *dialog,
     {
       default:
         g_warning ("Unexpected response: %d", response);
-        /* Fall through */
-      case GTK_RESPONSE_DELETE_EVENT:
         handle->response = 2;
         break;
+      case GTK_RESPONSE_DELETE_EVENT:
       case GTK_RESPONSE_CANCEL:
         handle->response = 1;
         break;


### PR DESCRIPTION
It's reasonable for an implementation to, e.g., fall back to a non-portal implementation if there's an error response.

However this portal currently returns 2 when the dialog is closed regularly, e.g. via the ESC key. This patch fixes it.

Fixes #499