### PR TITLE
Put dialogs in window groups

### DIFF
--- a/src/access.c
+++ b/src/access.c
@@ -241,6 +241,7 @@ handle_access_dialog (XdpImplAccess *object,
                       const char *arg_body,
                       GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const char *sender;
   AccessDialogHandle *handle;
@@ -350,6 +351,9 @@ G_GNUC_END_IGNORE_DEPRECATIONS
 G_GNUC_BEGIN_IGNORE_DEPRECATIONS
   gtk_message_dialog_set_image (GTK_MESSAGE_DIALOG (dialog), image);
 G_GNUC_END_IGNORE_DEPRECATIONS
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   handle = g_new0 (AccessDialogHandle, 1);
   handle->impl = object;

--- a/src/account.c
+++ b/src/account.c
@@ -147,6 +147,7 @@ handle_get_user_information (XdpImplAccount *object,
                              const char *arg_parent_window,
                              GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const char *sender;
   AccountDialogHandle *handle;
@@ -195,6 +196,9 @@ handle_get_user_information (XdpImplAccount *object,
   dialog = GTK_WIDGET (account_dialog_new (arg_app_id, user_name, real_name, icon_file, reason));
   gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
   gtk_window_set_modal (GTK_WINDOW (dialog), TRUE);
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   handle = g_new0 (AccountDialogHandle, 1);
   handle->impl = object;

--- a/src/appchooser.c
+++ b/src/appchooser.c
@@ -148,6 +148,7 @@ handle_choose_application (XdpImplAppChooser *object,
                            const char **choices,
                            GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   GtkWidget *dialog;
   AppDialogHandle *handle;
@@ -197,8 +198,10 @@ handle_choose_application (XdpImplAppChooser *object,
 
   dialog = GTK_WIDGET (app_chooser_dialog_new (choices, latest_chosen_id, content_type, location));
   gtk_window_set_transient_for (GTK_WINDOW (dialog), GTK_WINDOW (fake_parent));
-
   gtk_window_set_modal (GTK_WINDOW (dialog), modal);
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   handle = g_new0 (AppDialogHandle, 1);
   handle->impl = object;

--- a/src/dynamic-launcher.c
+++ b/src/dynamic-launcher.c
@@ -177,6 +177,7 @@ handle_prepare_install (XdpImplDynamicLauncher *object,
                         GVariant               *arg_icon_v,
                         GVariant               *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const char *sender;
   GdkDisplay *display;
@@ -323,6 +324,9 @@ handle_prepare_install (XdpImplDynamicLauncher *object,
     }
 
   gtk_dialog_set_default_response (GTK_DIALOG (dialog), GTK_RESPONSE_OK);
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   handle->dialog = g_object_ref (dialog);
   handle->entry = entry;

--- a/src/filechooser.c
+++ b/src/filechooser.c
@@ -407,6 +407,7 @@ handle_open (XdpImplFileChooser *object,
              const char *arg_title,
              GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const gchar *method_name;
   const gchar *sender;
@@ -503,6 +504,9 @@ handle_open (XdpImplFileChooser *object,
   gtk_file_chooser_set_preview_widget_active (GTK_FILE_CHOOSER (dialog), FALSE);
   gtk_file_chooser_set_use_preview_label (GTK_FILE_CHOOSER (dialog), FALSE);
   g_signal_connect (dialog, "update-preview", G_CALLBACK (update_preview_cb), preview);
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   handle = g_new0 (FileDialogHandle, 1);
   handle->impl = object;

--- a/src/print.c
+++ b/src/print.c
@@ -480,6 +480,7 @@ handle_print (XdpImplPrint *object,
               GVariant *arg_fd_in,
               GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const char *sender;
   GtkWidget *dialog;
@@ -552,6 +553,10 @@ handle_print (XdpImplPrint *object,
   gtk_window_set_modal (GTK_WINDOW (dialog), modal);
   gtk_print_unix_dialog_set_manual_capabilities (GTK_PRINT_UNIX_DIALOG (dialog),
                                                  print_capabilities_from_options (arg_options));
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
+
   handle = g_new0 (PrintDialogHandle, 1);
   handle->impl = object;
   handle->invocation = invocation;
@@ -653,6 +658,7 @@ handle_prepare_print (XdpImplPrint *object,
                       GVariant *arg_page_setup,
                       GVariant *arg_options)
 {
+  g_autoptr(GtkWindowGroup) window_group = NULL;
   g_autoptr(Request) request = NULL;
   const char *sender;
   GtkWidget *dialog;
@@ -702,6 +708,9 @@ handle_prepare_print (XdpImplPrint *object,
   gtk_print_unix_dialog_set_embed_page_setup (GTK_PRINT_UNIX_DIALOG (dialog), TRUE);
   gtk_print_unix_dialog_set_settings (GTK_PRINT_UNIX_DIALOG (dialog), settings);
   gtk_print_unix_dialog_set_page_setup (GTK_PRINT_UNIX_DIALOG (dialog), page_setup);
+
+  window_group = gtk_window_group_new ();
+  gtk_window_group_add_window (window_group, GTK_WINDOW (dialog));
 
   g_object_unref (settings);
   g_object_unref (page_setup);


### PR DESCRIPTION
That way, grabs only affect the dialog themselves. This is relevant for modal dialogs, which do take a grab on the window group - and since we don't put any dialogs into any window groups, they all take program-wide grabs, blocking other portal dialogs.

Closes: https://github.com/flatpak/xdg-desktop-portal-gtk/issues/334

See also:
- https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/issues/109
- https://gitlab.gnome.org/GNOME/xdg-desktop-portal-gnome/-/merge_requests/124