### PR TITLE
inhibit: Fix initial screensaver active state

### DIFF
--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -593,7 +593,7 @@ inhibit_init (GDBusConnection *bus,
 
           g_signal_connect (screensaver, "active-changed", G_CALLBACK (global_active_changed_cb), NULL);
           org_gnome_screen_saver_call_get_active_sync (screensaver, &active, NULL, NULL);
-          g_object_set_data (G_OBJECT (screensaver), "active", GINT_TO_POINTER (active));
+          screensaver_active = active;
 
           g_debug ("Using org.gnome.SessionManager for inhibit");
           g_debug ("Using org.gnome.Screensaver for screensaver state");
@@ -647,7 +647,7 @@ inhibit_init (GDBusConnection *bus,
 
       g_signal_connect (fdo_screensaver, "active-changed", G_CALLBACK (global_active_changed_cb), NULL);
       org_freedesktop_screen_saver_call_get_active_sync (fdo_screensaver, &active, NULL, NULL);
-      g_object_set_data (G_OBJECT (fdo_screensaver), "active", GINT_TO_POINTER (active));
+      screensaver_active = active;
 
       g_debug ("Using org.freedesktop.ScreenSaver for inhibit");
       g_debug ("Using org.freedesktop.ScreenSaver for screensaver state");


### PR DESCRIPTION
ef3b4ec changed how the local copy of the screensaver state is stored from object data to a global static variable, but did not change the code that sets the initial value.

----

Just a fix for something that I noticed while reading the code. I doubt this has ever lead to any issues in actual usage since that would require the portal to have been started with the screensaver already active and then followed by a session state change without deactivating the screensaver.