### PR TITLE
Do not create new wayland display if the gdk default display is wayland

### DIFF
--- a/src/externalwindow-wayland.c
+++ b/src/externalwindow-wayland.c
@@ -45,14 +45,24 @@ G_DEFINE_TYPE (ExternalWindowWayland, external_window_wayland,
 static GdkDisplay *
 get_wayland_display (void)
 {
+  GdkDisplay *default_display;
+
   if (wayland_display)
     return wayland_display;
 
-  gdk_set_allowed_backends ("wayland");
-  wayland_display = gdk_display_open (NULL);
-  gdk_set_allowed_backends (NULL);
-  if (!wayland_display)
-    g_warning ("Failed to open Wayland display");
+  default_display = gdk_display_get_default ();
+  if (GDK_IS_WAYLAND_DISPLAY (default_display))
+    {
+      wayland_display = default_display;
+    }
+  else
+    {
+      gdk_set_allowed_backends ("wayland");
+      wayland_display = gdk_display_open (NULL);
+      gdk_set_allowed_backends (NULL);
+      if (!wayland_display)
+        g_warning ("Failed to open Wayland display");
+    }
 
   return wayland_display;
 }


### PR DESCRIPTION
There are many different code refers to gdk_display_get_default as either module or internally. Having a display that is different from the default wayland display will create a new wl_display internally, while the object returns from different wl_display should not be used together.

This shall fix input method when im-wayland im module (default one used on wayland that implements text_input protocol) is used.

Fix #539