### PR TITLE
Stop using G_GNUC_CONST in _get_type functions

### DIFF
--- a/src/appchooserdialog.h
+++ b/src/appchooserdialog.h
@@ -28,7 +28,7 @@
 typedef struct _AppChooserDialog AppChooserDialog;
 typedef struct _AppChooserDialogClass AppChooserDialogClass;
 
-GType              app_chooser_dialog_get_type (void) G_GNUC_CONST;
+GType              app_chooser_dialog_get_type (void);
 
 AppChooserDialog * app_chooser_dialog_new (const char **app_ids,
                                            const char  *default_id,

--- a/src/request.h
+++ b/src/request.h
@@ -41,7 +41,7 @@ struct _RequestClass
   XdpImplRequestSkeletonClass parent_class;
 };
 
-GType request_get_type (void) G_GNUC_CONST;
+GType request_get_type (void);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (Request, g_object_unref)
 

--- a/src/wallpaperdialog.h
+++ b/src/wallpaperdialog.h
@@ -28,7 +28,7 @@
 typedef struct _WallpaperDialog WallpaperDialog;
 typedef struct _WallpaperDialogClass WallpaperDialogClass;
 
-GType             wallpaper_dialog_get_type (void) G_GNUC_CONST;
+GType             wallpaper_dialog_get_type (void);
 
 WallpaperDialog * wallpaper_dialog_new (const char *picture_uri,
                                         const char *app_id);

--- a/src/wallpaperpreview.h
+++ b/src/wallpaperpreview.h
@@ -28,7 +28,7 @@
 typedef struct _WallpaperPreview WallpaperPreview;
 typedef struct _WallpaperPreviewClass WallpaperPreviewClass;
 
-GType              wallpaper_preview_get_type  (void) G_GNUC_CONST;
+GType              wallpaper_preview_get_type  (void);
 
 void               wallpaper_preview_set_image (WallpaperPreview *self,
                                                 const gchar *image_uri);


### PR DESCRIPTION
As per g_type_ensure's documentation it is incorrect to mark _get_type functions with G_GNUC_CONST since they have side-effects on their first run.

See https://gitlab.gnome.org/GNOME/glib/-/merge_requests/5223 for more details.